### PR TITLE
fix: Do not mark root variables as unused when `checkRoot` is `true` (#3)

### DIFF
--- a/src/rules/sass/no-unused-variables/__tests__/no-unused-variables.implementation.test.ts
+++ b/src/rules/sass/no-unused-variables/__tests__/no-unused-variables.implementation.test.ts
@@ -278,7 +278,38 @@ testRule({
 testRule({
 	description: '`checkRoot` option',
 	config: [true, { checkRoot: true }],
-	accept: [],
+	accept: [
+		{
+			description: 'The root variable is used at the root level',
+			code: `
+				$foo: '.block';
+
+				#{$foo} {}
+			`,
+		},
+		{
+			description: 'The root variable is used inside the rule',
+			code: `
+				$foo: red;
+
+				.foo {
+					color: $foo;
+				}
+			`,
+		},
+		{
+			description: 'The root variable is used inside @at-rule',
+			code: `
+				$foo: red;
+
+				@media (screen) {
+					.foo {
+						color: $foo;
+					}
+				}
+			`,
+		},
+	],
 	reject: [
 		{
 			description: 'The only root property',

--- a/src/rules/sass/no-unused-variables/no-unused-variables.ts
+++ b/src/rules/sass/no-unused-variables/no-unused-variables.ts
@@ -89,7 +89,7 @@ export default createRule({
 	// Returns the closest parent scope, if any.
 	const getParentScopeNode = (node: Node): Node | null => {
 		let parent: Node | undefined = node.parent;
-		while (parent && parent !== root) {
+		while (parent && (secondary.checkRoot || parent !== root)) {
 			if (scopesMap.has(parent)) return parent;
 			parent = parent.parent;
 		}


### PR DESCRIPTION
#### Description

Adds tests for positive scenario of using variables at root level and fixes usage check condition.

#### Linked issue

Closes #3 
