### PR TITLE
fix(block-variable): Replace with `&` instead of variable at root level if unambiguous

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"@morev/commitlint-config": "^0.2.2",
 		"@morev/eslint-config": "^40.0.0",
 		"@morev/stylelint-config": "^8.0.1",
-		"@morev/stylelint-testing-library": "^1.0.0",
+		"@morev/stylelint-testing-library": "^1.0.1",
 		"@release-it/conventional-changelog": "8",
 		"@total-typescript/ts-reset": "^0.6.1",
 		"@types/node": "22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.2(stylelint@16.23.1(typescript@5.9.2))
       '@morev/stylelint-testing-library':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       '@release-it/conventional-changelog':
         specifier: '8'
         version: 8.0.2(release-it@19.0.4(@types/node@22.18.0)(magicast@0.3.5))
@@ -938,8 +938,9 @@ packages:
     peerDependencies:
       stylelint: ^16.18.0
 
-  '@morev/stylelint-testing-library@1.0.0':
-    resolution: {integrity: sha512-u8WkS47Xz11jLm2o+0xambpYijDyjb3epnyTV/1l799JcDJBEGI8gS/ynip4/hHcteecBlR5oXJK7wmu/qEabw==}
+  '@morev/stylelint-testing-library@1.0.1':
+    resolution: {integrity: sha512-exQQk5w9FwsoqwY7z5hUtPAi0TtzhChf5AjOWgrlybzCUdaigjJFxmwf4OvqEQBx1WI3GNxtlJvTWzlN2+RgWA==}
+    engines: {node: '>=18'}
 
   '@morev/utils@2.8.1':
     resolution: {integrity: sha512-q++LKjbWTUt8cZIvnDLUnt+6LXsgiUmfW5S3kaPST4bR/FXhoU87hwua9DfgqW6ht11CwgOyGeQ14ktV51somw==}
@@ -6065,7 +6066,7 @@ snapshots:
       stylelint-selector-tag-no-without-class: 3.0.1(stylelint@16.23.1(typescript@5.9.2))
       stylelint-use-nesting: 6.0.0(stylelint@16.23.1(typescript@5.9.2))
 
-  '@morev/stylelint-testing-library@1.0.0':
+  '@morev/stylelint-testing-library@1.0.1':
     dependencies:
       '@morev/utils': 3.13.1
 

--- a/src/rules/bem/block-variable/block-variable.types.ts
+++ b/src/rules/bem/block-variable/block-variable.types.ts
@@ -29,8 +29,8 @@ export type SecondaryOption = {
 	firstChild?: boolean;
 
 	/**
-	 * Whether to automatically replace hardcoded occurrences of the block name
-	 * inside nested selectors with the corresponding block variable.
+	 * Whether to automatically replace hardcoded block names with the block variable
+	 * in descendant selectors, or with `&` when safely possible in root selectors.
 	 *
 	 * @default true
 	 */
@@ -92,14 +92,22 @@ export type SecondaryOption = {
 		duplicatedVariable?: (foundName: string, expectedName: string) => string;
 
 		/**
-		 * Reported when a hardcoded block name is used inside a nested selector
-		 * instead of the block reference variable.
+		 * Reported when a hardcoded block name is used instead of a safe reference.
 		 *
 		 * @param   blockSelector   The hardcoded block selector found (e.g., ".the-component").
-		 * @param   variableName    The variable reference that should be used (e.g., "#{$b}").
+		 * @param   variableRef     The block reference variable that should be used (e.g., "#{$b}").
+		 * @param   context         Where the hardcoded selector was found.
+		 *                          - `root`: `.foo { .foo__el {} }`
+		 *                          - `nested`: `.foo { &__el { .foo__bar {} } }`
+		 * @param   fixable         Whether the case can be safely auto-fixed.
 		 *
 		 * @returns                 The error message to report.
 		 */
-		hardcodedBlockName?: (blockSelector: string, variableName: string) => string;
+		hardcodedBlockName?: (
+			blockSelector: string,
+			variableRef: string,
+			context: 'root' | 'nested',
+			fixable: boolean,
+		) => string;
 	};
 };


### PR DESCRIPTION
#### Description

Root-level hardcoded block names are most likely mistakes (extra specificity in BEM is usually unnecessary), but in some cases they can be intentional. There's no reliable way to guess the author's intent.

```scss
.the-component {
  // 🤔 What did the author intend here?
  .the-component__title {}
  
  // Probably meant:
  // &__title {}

  // Or intentionally bumped specificity:
  // & &__title {}
}
```

Because of that, the rule now auto-fixes where the correct replacement is unambiguous, and simply reports in cases where the outcome could be ambiguous or unsafe.

#### Linked issue

Closes #4 

