### PR TITLE
feat: Check declarations within block at-rules

### DIFF
--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.test.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.test.ts
@@ -3,42 +3,6 @@ import { getRuleDeclarations } from './get-rule-declarations';
 import type { Rule } from 'postcss';
 
 describe(getRuleDeclarations, () => {
-	it('Returns all declarations by default', () => {
-		const rule = getRuleBySelector<Rule>(`
-			.foo {
-				color: red;
-				@media (min-width: 600px) {
-					margin: 10px;
-				}
-				.bar {
-					padding: 5px;
-				}
-			}
-		`);
-
-		const decls = getRuleDeclarations(rule);
-
-		expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'margin', 'padding']);
-	});
-
-	it('Returns only direct child declarations when `onlyDirectChildren` is `true`', () => {
-		const rule = getRuleBySelector<Rule>(`
-			.foo {
-				color: red;
-				@media (min-width: 600px) {
-					margin: 10px;
-				}
-				.bar {
-					padding: 5px;
-				}
-			}
-		`);
-
-		const decls = getRuleDeclarations(rule, { onlyDirectChildren: true });
-
-		expect(decls.map((d) => d.prop)).toStrictEqual(['color']);
-	});
-
 	it('Handles empty rules gracefully', () => {
 		const rule = getRuleBySelector<Rule>(`.foo {}`);
 		const decls = getRuleDeclarations(rule);
@@ -46,17 +10,153 @@ describe(getRuleDeclarations, () => {
 		expect(decls).toStrictEqual([]);
 	});
 
-	it('Collects multiple direct children', () => {
-		const rule = getRuleBySelector<Rule>(`
-			.foo {
-				color: red;
-				background: blue;
-				border: 1px solid black;
-			}
-		`);
+	describe('Mode: deep (default)', () => {
+		it('Returns all declarations by default', () => {
+			const rule = getRuleBySelector<Rule>(`
+				.foo {
+					color: red;
 
-		const decls = getRuleDeclarations(rule, { onlyDirectChildren: true });
+					@media (min-width: 600px) {
+						margin: 10px;
+					}
 
-		expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'background', 'border']);
+					.bar {
+						padding: 5px;
+					}
+				}
+			`);
+
+			const decls = getRuleDeclarations(rule);
+
+			expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'margin', 'padding']);
+		});
+	});
+
+	describe('Mode: direct', () => {
+		it('Returns only direct child declarations when `onlyDirectChildren` is `true`', () => {
+			const rule = getRuleBySelector<Rule>(`
+				.foo {
+					color: red;
+					@media (min-width: 600px) {
+						margin: 10px;
+					}
+					.bar {
+						padding: 5px;
+					}
+				}
+			`);
+
+			const decls = getRuleDeclarations(rule, { mode: 'direct' });
+
+			expect(decls.map((d) => d.prop)).toStrictEqual(['color']);
+		});
+
+		it('Collects multiple direct children', () => {
+			const rule = getRuleBySelector<Rule>(`
+				.foo {
+					color: red;
+					background: blue;
+					border: 1px solid black;
+				}
+			`);
+
+			const decls = getRuleDeclarations(rule, { mode: 'direct' });
+
+			expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'background', 'border']);
+		});
+	});
+
+	describe('Mode: directWithPureAtRules', () => {
+		it('Returns direct declarations + declarations from pure at-rules (default `shape: "nodes"`) ', () => {
+			const rule = getRuleBySelector<Rule>(`
+				.foo {
+					color: red;
+
+					@font-face {
+						font-family: Test;
+						src: url(foo.woff2) format('woff2');
+					}
+
+					@supports (display: grid) {
+						opacity: .9;
+					}
+
+					@media (min-width: 600px) {
+						.bar { margin: 10px; }
+					}
+				}
+			`);
+
+			const decls = getRuleDeclarations(rule, { mode: 'directWithPureAtRules' });
+
+			expect(decls.map((d) => d.prop)).toStrictEqual([
+				'color', // direct
+				'font-family', // from @font-face
+				'src', // from @font-face
+				'opacity', // from @supports
+				// no 'margin' because @media contains a Rule
+			]);
+		});
+
+		it('Returns with path when `shape: "withPath"`', () => {
+			const rule = getRuleBySelector<Rule>(`
+				.foo {
+					background: blue;
+
+					@font-face {
+						font-family: Test;
+					}
+
+					@supports (display: grid) {
+						opacity: .9;
+					}
+
+					@layer components {
+						@supports (display: contents) {
+							outline: 1px solid red;
+						}
+					}
+
+					@media (min-width: 600px) {
+						.bar { padding: 5px; }
+					}
+				}
+			`);
+
+			const declsWithPath = getRuleDeclarations(rule, {
+				mode: 'directWithPureAtRules',
+				shape: 'withPath',
+			});
+
+			// 1 direct + 1 (font-face) + 1 (supports) + 1 (layer-supports) = 4
+			expect(declsWithPath).toHaveLength(4);
+
+			// Direct declaration has an empty path
+			const direct = declsWithPath.find((x) => x.declaration.prop === 'background')!;
+
+			expect(direct).toBeTruthy();
+			expect(direct.atRulePath).toStrictEqual([]);
+
+			// @font-face → path = ['font-face']
+			const ff = declsWithPath.find((x) => x.declaration.prop === 'font-family')!;
+
+			expect(ff).toBeTruthy();
+			expect(ff.atRulePath.map((a) => a.name)).toStrictEqual(['font-face']);
+
+			// @supports → path = ['supports']
+			const op = declsWithPath.find((x) => x.declaration.prop === 'opacity')!;
+
+			expect(op).toBeTruthy();
+			expect(op.atRulePath.map((a) => a.name)).toStrictEqual(['supports']);
+
+			// @layer → @supports → path = ['layer', 'supports']
+			const outline = declsWithPath.find((x) => x.declaration.prop === 'outline')!;
+
+			expect(outline).toBeTruthy();
+			expect(outline.atRulePath.map((a) => a.name)).toStrictEqual(['layer', 'supports']);
+
+			// Ensure non-pure @media branch didn't leak declarations
+			expect(declsWithPath.find((x) => x.declaration.prop === 'padding')).toBeUndefined();
+		});
 	});
 });

--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.test.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.test.ts
@@ -1,0 +1,62 @@
+import { getRuleBySelector } from '#modules/test-utils';
+import { getRuleDeclarations } from './get-rule-declarations';
+import type { Rule } from 'postcss';
+
+describe(getRuleDeclarations, () => {
+	it('Returns all declarations by default', () => {
+		const rule = getRuleBySelector<Rule>(`
+			.foo {
+				color: red;
+				@media (min-width: 600px) {
+					margin: 10px;
+				}
+				.bar {
+					padding: 5px;
+				}
+			}
+		`);
+
+		const decls = getRuleDeclarations(rule);
+
+		expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'margin', 'padding']);
+	});
+
+	it('Returns only direct child declarations when `onlyDirectChildren` is `true`', () => {
+		const rule = getRuleBySelector<Rule>(`
+			.foo {
+				color: red;
+				@media (min-width: 600px) {
+					margin: 10px;
+				}
+				.bar {
+					padding: 5px;
+				}
+			}
+		`);
+
+		const decls = getRuleDeclarations(rule, { onlyDirectChildren: true });
+
+		expect(decls.map((d) => d.prop)).toStrictEqual(['color']);
+	});
+
+	it('Handles empty rules gracefully', () => {
+		const rule = getRuleBySelector<Rule>(`.foo {}`);
+		const decls = getRuleDeclarations(rule);
+
+		expect(decls).toStrictEqual([]);
+	});
+
+	it('Collects multiple direct children', () => {
+		const rule = getRuleBySelector<Rule>(`
+			.foo {
+				color: red;
+				background: blue;
+				border: 1px solid black;
+			}
+		`);
+
+		const decls = getRuleDeclarations(rule, { onlyDirectChildren: true });
+
+		expect(decls.map((d) => d.prop)).toStrictEqual(['color', 'background', 'border']);
+	});
+});

--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
@@ -1,34 +1,62 @@
-import type { Declaration, Rule } from 'postcss';
+import { isAtRule } from '#modules/postcss/is-at-rule/is-at-rule';
+import { collectDeclarationsWithPath, isPureAtRule } from './utils';
+import type { AtRule, Declaration, Rule } from 'postcss';
+import type { DeclarationWithAtRulePath, Options } from './get-rule-declarations.types';
 
-type Options = {
-	/**
-	 * Whether to return only direct child declarations.
-	 *
-	 * @default false
-	 */
-	onlyDirectChildren: boolean;
-};
+type ToReturn<T extends Options> =
+	T['mode'] extends 'directWithPureAtRules'
+		? T['shape'] extends 'nodes'
+			? Declaration[]
+			: DeclarationWithAtRulePath[]
+		: Declaration[];
 
 /**
- * Collects `postcss.Declaration` nodes from a given `postcss.Rule`.
+ * Collects declarations from a given `Rule` or `AtRule` node,
+ * with flexible strategies depending on the selected `mode`.
  *
- * @param   rule      A PostCSS `Rule` node to inspect.
- * @param   options   Optional settings.
+ * - In `'deep'` mode, it walks the full subtree and returns **all** declarations.
+ * - In `'direct'` mode, it returns only **direct child declarations**.
+ * - In `'directWithPureAtRules'` mode, it returns both direct declarations and
+ * those inside **pure at-rules** (at-rules that do not contain selectors).
+ * You can choose to return raw `Declaration` nodes or include their `atRulePath`.
  *
- * @returns           An array of `Declaration` nodes matching the given criteria.
+ * @param   rule      A PostCSS `Rule` or `AtRule` node to inspect.
+ * @param   options   Configuration determining how declarations are collected.
+ *
+ * @returns           Depending on `mode` and `shape`, returns either
+ *                    `Declaration[]` or `DeclarationWithAtRulePath[]`.
  */
-export const getRuleDeclarations = (
-	rule: Rule,
-	options: Partial<Options> = {},
-): Declaration[] => {
-	const { onlyDirectChildren = false } = options;
+export const getRuleDeclarations = <T extends Options>(
+	rule: Rule | AtRule,
+	options: Partial<T> = {},
+): ToReturn<T> => {
+	const { mode = 'deep' } = options;
 
-	if (!onlyDirectChildren) {
+	if (mode === 'deep') {
 		const declarations: Declaration[] = [];
 		// `.walkDecls()` traverses all the declarations.
 		rule.walkDecls((decl) => { declarations.push(decl); });
-		return declarations;
+		return declarations as ToReturn<T>;
 	}
 
-	return (rule.nodes ?? []).filter((node) => node.type === 'decl');
+	if (mode === 'direct') {
+		return (rule.nodes ?? []).filter((node) => node.type === 'decl') as ToReturn<T>;
+	}
+
+	const result: DeclarationWithAtRulePath[] = (rule.nodes ?? [])
+		.filter((node) => node.type === 'decl')
+		.map((node) => ({ declaration: node, atRulePath: [] }));
+
+	for (const node of rule.nodes ?? []) {
+		if (!isAtRule(node)) continue;
+		if (!isPureAtRule(node)) continue;
+
+		result.push(...collectDeclarationsWithPath(node));
+	}
+
+	if ('shape' in options && options.shape === 'withPath') {
+		return result as ToReturn<T>;
+	}
+
+	return result.map((entry) => entry.declaration) as ToReturn<T>;
 };

--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
@@ -1,31 +1,34 @@
 import type { Declaration, Rule } from 'postcss';
 
 type Options = {
+	/**
+	 * Whether to return only direct child declarations.
+	 *
+	 * @default false
+	 */
 	onlyDirectChildren: boolean;
 };
 
-const DEFAULTS = {
-	onlyDirectChildren: false,
-};
-
+/**
+ * Collects `postcss.Declaration` nodes from a given `postcss.Rule`.
+ *
+ * @param   rule      A PostCSS `Rule` node to inspect.
+ * @param   options   Optional settings.
+ *
+ * @returns           An array of `Declaration` nodes matching the given criteria.
+ */
 export const getRuleDeclarations = (
 	rule: Rule,
-	userOptions?: Partial<Options>,
+	options: Partial<Options> = {},
 ): Declaration[] => {
-	const declarations: Declaration[] = [];
-	const options = { ...DEFAULTS, ...userOptions };
+	const { onlyDirectChildren = false } = options;
 
-	if (!options.onlyDirectChildren) {
+	if (!onlyDirectChildren) {
+		const declarations: Declaration[] = [];
 		// `.walkDecls()` traverses all the declarations.
-		rule.walkDecls((declaration) => { declarations.push(declaration); });
+		rule.walkDecls((decl) => { declarations.push(decl); });
 		return declarations;
 	}
 
-	// `.each()` traverses only direct children.
-	rule.each((node) => {
-		if (node.type !== 'decl') return;
-		declarations.push(node);
-	});
-
-	return declarations;
+	return (rule.nodes ?? []).filter((node) => node.type === 'decl');
 };

--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.ts
@@ -1,13 +1,10 @@
-import { isNullish } from '@morev/utils';
 import type { Declaration, Rule } from 'postcss';
 
 type Options = {
-	filter: string | RegExp | null;
 	onlyDirectChildren: boolean;
 };
 
 const DEFAULTS = {
-	filter: null,
 	onlyDirectChildren: false,
 };
 
@@ -18,34 +15,17 @@ export const getRuleDeclarations = (
 	const declarations: Declaration[] = [];
 	const options = { ...DEFAULTS, ...userOptions };
 
-	if (isNullish(options.filter)) {
-		if (!options.onlyDirectChildren) {
-			// `.walkDecls()` traverses all the declarations.
-			rule.walkDecls((declaration) => { declarations.push(declaration); });
-			return declarations;
-		}
-
-		// `.each()` traverses only direct children.
-		rule.each((node) => {
-			if (node.type !== 'decl') return;
-			declarations.push(node);
-		});
-		return declarations;
-	}
-
 	if (!options.onlyDirectChildren) {
-		rule.walkDecls(options.filter, (declaration) => { declarations.push(declaration); });
+		// `.walkDecls()` traverses all the declarations.
+		rule.walkDecls((declaration) => { declarations.push(declaration); });
 		return declarations;
 	}
 
+	// `.each()` traverses only direct children.
 	rule.each((node) => {
 		if (node.type !== 'decl') return;
-
-		if (options.filter) {
-			node.prop.match(options.filter) && declarations.push(node);
-		} else {
-			declarations.push(node);
-		}
+		declarations.push(node);
 	});
+
 	return declarations;
 };

--- a/src/modules/postcss/get-rule-declarations/get-rule-declarations.types.ts
+++ b/src/modules/postcss/get-rule-declarations/get-rule-declarations.types.ts
@@ -1,0 +1,55 @@
+import type { AtRule, Declaration } from 'postcss';
+
+export type DeclarationWithAtRulePath = {
+	/**
+	 * The declaration node itself.
+	 */
+	declaration: Declaration;
+
+	/**
+	 * Path of ancestor at-rules enclosing the declaration,
+	 * ordered from the outermost to the innermost at-rule.
+	 * Empty array means the declaration is a direct child of the rule.
+	 */
+	atRulePath: AtRule[];
+};
+
+/**
+ * Available modes for collecting declarations from a `Rule` or `AtRule`.
+ */
+export type Options =
+	| {
+		/**
+		 * Collects all declarations recursively, regardless of their nesting level.
+		 *
+		 * Uses `.walkDecls()` under the hood.
+		 */
+		mode: 'deep';
+		shape: never;
+	}
+	| {
+		/**
+		 * Collects only direct child declarations of the node.
+		 */
+		mode: 'direct';
+		shape: never;
+	}
+	| {
+		/**
+		 * Collects direct child declarations plus declarations from
+		 * nested pure at-rules (at-rules containing no `Rule` nodes).
+		 *
+		 * This is useful for cases like `@font-face`, `@page`, `@keyframes`,
+		 * or nested conditional groups like `@supports` / `@media` that wrap
+		 * declarations without introducing selector rules.
+		 */
+		mode: 'directWithPureAtRules';
+
+		/**
+		 * Defines the return shape:
+		 * - `'nodes'` — returns a flat array of `Declaration` nodes.
+		 * - `'withPath'` — returns `DeclarationWithAtRulePath[]`, which keeps
+		 * track of the chain of at-rules leading to each declaration.
+		 */
+		shape: 'nodes' | 'withPath';
+	};

--- a/src/modules/postcss/get-rule-declarations/utils/collect-declarations-with-path/collect-declarations-with-path.test.ts
+++ b/src/modules/postcss/get-rule-declarations/utils/collect-declarations-with-path/collect-declarations-with-path.test.ts
@@ -1,0 +1,108 @@
+import { getRuleBySelector } from '#modules/test-utils';
+import { collectDeclarationsWithPath } from './collect-declarations-with-path';
+import type { AtRule } from 'postcss';
+
+describe(collectDeclarationsWithPath, () => {
+	it('Returns an empty array for an empty pure at-rule', () => {
+		const atRule = getRuleBySelector<AtRule>('@media (min-width: 768px) {}');
+		const result = collectDeclarationsWithPath(atRule);
+
+		expect(result).toStrictEqual([]);
+	});
+
+	it('Skips empty nested at-rules and still returns an empty array when no declarations exist', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@media (min-width: 768px) {
+				@supports (display: grid) {}
+				@layer utilities {}
+			}
+		`);
+
+		const result = collectDeclarationsWithPath(at);
+
+		expect(result).toStrictEqual([]);
+	});
+
+	it('Collects direct declarations with path containing only the root at-rule', () => {
+		const atRule = getRuleBySelector<AtRule>(`
+			@font-face {
+				font-family: Test;
+				src: url(foo.woff2) format('woff2');
+			}
+		`);
+
+		const result = collectDeclarationsWithPath(atRule);
+
+		expect(result).toHaveLength(2);
+
+		expect(result.map((entry) => entry.declaration.prop))
+			.toStrictEqual(['font-family', 'src']);
+
+		for (const item of result) {
+			expect(item.atRulePath).toHaveLength(1);
+			expect(item.atRulePath[0].name).toBe('font-face');
+		}
+	});
+
+	it('Collects declarations nested inside inner at-rules and preserves the path', () => {
+		const atRule = getRuleBySelector<AtRule>(`
+			@media (min-width: 768px) {
+				@supports (display: grid) {
+					color: red;
+					background: blue;
+				}
+			}
+		`);
+
+		const result = collectDeclarationsWithPath(atRule);
+
+		expect(result).toHaveLength(2);
+
+		const color = result.find((x) => x.declaration.prop === 'color');
+
+		expect(color).toBeTruthy();
+		expect(color!.atRulePath.map((a) => a.name)).toStrictEqual(['media', 'supports']);
+
+		const bg = result.find((x) => x.declaration.prop === 'background');
+
+		expect(bg).toBeTruthy();
+		expect(bg!.atRulePath.map((a) => a.name)).toStrictEqual(['media', 'supports']);
+	});
+
+	it('Collects declarations across multiple branches (order agnostic) with correct **paths**', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@media (min-width: 768px) {
+				@supports (display: grid) {
+					color: red;
+				}
+
+				@layer components {
+					@supports (display: contents) {
+						margin: 0;
+					}
+				}
+
+				opacity: .9;
+			}
+		`);
+
+		const result = collectDeclarationsWithPath(at);
+
+		expect(result).toHaveLength(3);
+
+		const color = result.find((x) => x.declaration.prop === 'color');
+
+		expect(color).toBeTruthy();
+		expect(color!.atRulePath.map((a) => a.name)).toStrictEqual(['media', 'supports']);
+
+		const margin = result.find((x) => x.declaration.prop === 'margin');
+
+		expect(margin).toBeTruthy();
+		expect(margin!.atRulePath.map((a) => a.name)).toStrictEqual(['media', 'layer', 'supports']);
+
+		const opacity = result.find((x) => x.declaration.prop === 'opacity');
+
+		expect(opacity).toBeTruthy();
+		expect(opacity!.atRulePath.map((a) => a.name)).toStrictEqual(['media']);
+	});
+});

--- a/src/modules/postcss/get-rule-declarations/utils/collect-declarations-with-path/collect-declarations-with-path.ts
+++ b/src/modules/postcss/get-rule-declarations/utils/collect-declarations-with-path/collect-declarations-with-path.ts
@@ -1,0 +1,58 @@
+import type { AtRule, ChildNode } from 'postcss';
+import type { DeclarationWithAtRulePath } from '../../get-rule-declarations.types';
+
+type Frame = { node: ChildNode; path: AtRule[] };
+
+/**
+ * Collects all declarations contained within a given **pure at-rule**,
+ * along with the full chain of at-rules leading to each declaration.
+ *
+ * Traverses the at-rule tree depth-first using an explicit stack, and
+ * returns each declaration together with the path of nested at-rules
+ * that enclose it.
+ *
+ * @example
+ * ```scss
+ * @media (min-width: 768px) {
+ *   @supports (display: grid) {
+ *     color: red;
+ *   }
+ * }
+ * ```
+ * Produces:
+ * [
+ *   {
+ *     declaration: <Decl "color: red">,
+ *     atRulePath: [<AtRule "@media">, <AtRule "@supports">]
+ *   }
+ * ]
+ *
+ * @param   rootAtRule   The root pure at-rule node to collect declarations from.
+ *
+ * @returns              An array of declarations with their corresponding at-rule path.
+ */
+export const collectDeclarationsWithPath = (
+	rootAtRule: AtRule,
+): DeclarationWithAtRulePath[] => {
+	const result: DeclarationWithAtRulePath[] = [];
+	const stack: Frame[] = (rootAtRule.nodes ?? [])
+		.map((node) => ({ node, path: [rootAtRule] }));
+
+	while (stack.length) {
+		const { node, path } = stack.pop()!;
+
+		if (node.type === 'decl') {
+			result.push({ declaration: node, atRulePath: path });
+			continue;
+		}
+
+		if (node.type === 'atrule') {
+			const inner = node.nodes ?? [];
+			for (let i = inner.length - 1; i >= 0; i--) {
+				stack.push({ node: inner[i], path: [...path, node] });
+			}
+		}
+	}
+
+	return result.reverse();
+};

--- a/src/modules/postcss/get-rule-declarations/utils/index.ts
+++ b/src/modules/postcss/get-rule-declarations/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './collect-declarations-with-path/collect-declarations-with-path';
+export * from './is-pure-at-rule/is-pure-at-rule';

--- a/src/modules/postcss/get-rule-declarations/utils/is-pure-at-rule/is-pure-at-rule.test.ts
+++ b/src/modules/postcss/get-rule-declarations/utils/is-pure-at-rule/is-pure-at-rule.test.ts
@@ -1,0 +1,77 @@
+import { getRuleBySelector } from '#modules/test-utils';
+import { isPureAtRule } from './is-pure-at-rule';
+import type { AtRule } from 'postcss';
+
+describe(isPureAtRule, () => {
+	it('Returns `true` for an empty at-rule', () => {
+		const at = getRuleBySelector<AtRule>('@media (min-width: 768px) {}');
+
+		expect(isPureAtRule(at)).toBe(true);
+	});
+
+	it('Returns `true` for an at-rule containing only empty nested at-rules', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@supports (display: grid) {
+				@media (min-width: 768px) {
+					@layer utilities {}
+				}
+				@layer utilities {}
+			}
+		`);
+
+		expect(isPureAtRule(at)).toBe(true);
+	});
+
+	it('Returns `true` for at-rules that contain only declarations (e.g., `@font-face`)', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@font-face {
+				font-family: Test;
+				src: url(test.woff2) format('woff2');
+				font-weight: 400;
+				font-style: normal;
+			}
+		`);
+
+		expect(isPureAtRule(at)).toBe(true);
+	});
+
+	it('Returns `false` when a direct child `Rule` is present', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@media (min-width: 768px) {
+				.foo { color: red; }
+			}
+		`);
+
+		expect(isPureAtRule(at)).toBe(false);
+	});
+
+	it('Returns `false` when a nested at-rule contains a `Rule` deep inside', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@supports (display: grid) {
+				@media (min-width: 768px) {
+					.foo { color: red; }
+				}
+			}
+		`);
+
+		expect(isPureAtRule(at)).toBe(false);
+	});
+
+	it('Ignores comments and returns `true` if there are no `Rule` nodes', () => {
+		const at = getRuleBySelector<AtRule>(`
+			@media (min-width: 768px) {
+				/* comment */
+				@layer components {}
+				/* another comment */
+			}
+		`);
+
+		expect(isPureAtRule(at)).toBe(true);
+	});
+
+	it('Handles at-rules without `nodes` safely (returns `true`)', () => {
+		const at = getRuleBySelector<AtRule>('@supports (display: grid) {}');
+
+		expect(isPureAtRule(at)).toBe(true);
+	});
+});

--- a/src/modules/postcss/get-rule-declarations/utils/is-pure-at-rule/is-pure-at-rule.ts
+++ b/src/modules/postcss/get-rule-declarations/utils/is-pure-at-rule/is-pure-at-rule.ts
@@ -1,0 +1,30 @@
+import { isEmpty } from '@morev/utils';
+import { isAtRule } from '#modules/postcss/is-at-rule/is-at-rule';
+import { isRule } from '#modules/postcss/is-rule/is-rule';
+import type { AtRule, ChildNode } from 'postcss';
+
+/**
+ * Determines whether the given at-rule is **pure**, meaning it does not
+ * contain any style rules (`Rule` nodes) directly or nested within other
+ * non-empty at-rules.
+ *
+ * In other words, a pure at-rule can contain only other empty at-rules or no
+ * children at all.
+ *
+ * @param   rule   The PostCSS at-rule node to check.
+ *
+ * @returns        `true` if the at-rule is pure, otherwise `false`.
+ */
+export const isPureAtRule = (rule: AtRule) => {
+	const stack: ChildNode[] = [...(rule.nodes ?? [])];
+
+	while (stack.length) {
+		const current = stack.pop()!;
+		if (isRule(current)) return false;
+		if (isAtRule(current) && !isEmpty(current.nodes)) {
+			stack.push(...current.nodes);
+		}
+	}
+
+	return true;
+};

--- a/src/modules/test-utils/get-rule-by-selector.ts
+++ b/src/modules/test-utils/get-rule-by-selector.ts
@@ -19,10 +19,10 @@ import { getRuleContentMeta, isAtRule, isRule } from '#modules/postcss';
  *
  * @throws If no matching rule or at-rule is found for the provided selector.
  */
-export const getRuleBySelector = (
+export const getRuleBySelector = <T extends postcss.Rule | postcss.AtRule>(
 	rootOrSource: postcss.Root | string,
 	selector?: string,
-): postcss.Rule | postcss.AtRule => {
+): T => {
 	let found: postcss.Rule | postcss.AtRule | null = null;
 
 	const root = isString(rootOrSource)
@@ -33,7 +33,7 @@ export const getRuleBySelector = (
 		const firstNode = root.nodes[0];
 
 		if (isAtRule(firstNode) || isRule(firstNode)) {
-			return firstNode;
+			return firstNode as T;
 		}
 
 		throw new Error(`Rule not found`);

--- a/src/rules/bem/block-variable/block-variable.ts
+++ b/src/rules/bem/block-variable/block-variable.ts
@@ -117,7 +117,7 @@ export default createRule({
 	})();
 
 	const nodeChildDeclarations = getRuleDeclarations(bemBlock.rule, {
-		onlyDirectChildren: true,
+		mode: 'direct',
 	});
 
 	const allBlockVariableDeclarations = nodeChildDeclarations

--- a/src/rules/bem/no-block-properties/__tests__/no-block-properties.implementation.test.ts
+++ b/src/rules/bem/no-block-properties/__tests__/no-block-properties.implementation.test.ts
@@ -66,6 +66,29 @@ testRule({
 				.foo-component__item:has(.card) { margin-block-start: 16px; }
 			`,
 		},
+		{
+			description: 'Does not report disallowed properties inside SASS control structures and some of CSS at-rules',
+			code: `
+				.the-component {
+				 	@keyframes bounce {
+						from { margin-block-start: 0 }
+						to { margin-block-start: 24px }
+					}
+
+					@page {
+						margin: 10mm;
+					}
+
+					@mixin foo() {
+						margin: 24px;
+					}
+
+					@function bar() {
+						margin: 24px;
+					}
+				}
+			`,
+		},
 	],
 	reject: [
 		{
@@ -221,6 +244,43 @@ testRule({
 					message: messages.unexpected('margin-block-start', '.the-component', 'block', 'EXTERNAL_GEOMETRY'),
 					line: 3, column: 3,
 					endLine: 3, endColumn: 21,
+				},
+			],
+		},
+		{
+			description: 'Block has an external geometry property in at-rule',
+			code: `
+				.the-component {
+					@media (--tablet-portrait) {
+						margin-block-start: 16px;
+					}
+
+					@include responsive('xs') {
+						margin-block-start: 16px;
+					}
+
+					@layer components {
+						@media (--tablet-portrait) {
+							margin-block-start: 16px;
+						}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.unexpected('margin-block-start', '.the-component', 'block', 'EXTERNAL_GEOMETRY'),
+					line: 3, column: 3,
+					endLine: 3, endColumn: 21,
+				},
+				{
+					message: messages.unexpected('margin-block-start', '.the-component', 'block', 'EXTERNAL_GEOMETRY'),
+					line: 7, column: 3,
+					endLine: 7, endColumn: 21,
+				},
+				{
+					message: messages.unexpected('margin-block-start', '.the-component', 'block', 'EXTERNAL_GEOMETRY'),
+					line: 12, column: 4,
+					endLine: 12, endColumn: 22,
 				},
 			],
 		},

--- a/src/rules/bem/no-block-properties/no-block-properties.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.ts
@@ -104,9 +104,9 @@ export default createRule({
 				});
 
 				const entitiesToReport = selectorBemEntities
-				// We are looking only for BEM blocks or its modifiers in the rule
+					// We are looking only for BEM blocks or its modifiers in the rule
 					.filter((bemEntity) => !bemEntity.element)
-				// Skip ignored blocks
+					// Skip ignored blocks
 					.filter((bemEntity) => {
 						return !ignorePatterns
 							.some((blockPattern) => blockPattern.test(bemEntity.block.value));
@@ -117,8 +117,19 @@ export default createRule({
 				entitiesToReport.forEach((bemEntity) => {
 					const context = bemEntity.modifierName ? 'modifier' : 'block';
 
-					const declarationsToReport = getRuleDeclarations(rule, { onlyDirectChildren: true })
-						.filter((declaration) => disallowedProperties[context].has(declaration.prop));
+					const declarationsToReport = getRuleDeclarations(rule, {
+						mode: 'directWithPureAtRules',
+						shape: 'withPath',
+					})
+						.filter(({ declaration }) => {
+							return disallowedProperties[context].has(declaration.prop);
+						})
+						.filter(({ atRulePath }) => {
+							return !atRulePath.some((atRule) => {
+								return ['page', 'mixin', 'function'].includes(atRule.name);
+							});
+						})
+						.map(({ declaration }) => declaration);
 
 					declarationsToReport.forEach((declaration) => {
 						report({


### PR DESCRIPTION
#### Description

This adds property checking inside at-rules at the BEM block level and its modifiers, except for SASS control structures and some CSS rules like `@page`.

There is still no support for `@at-root` here, but I hope that this will never be a problem in real-world use.

#### Linked issue

Closes #8 