### PR TITLE
feat: Support Stylelint per-rule secondary options in all rules

### DIFF
--- a/docs/_parts/stylelint-wide-options.md
+++ b/docs/_parts/stylelint-wide-options.md
@@ -1,0 +1,15 @@
+::: details Show info about Stylelint-wide options
+
+Every rule in this plugin also supports the standard Stylelint per-rule options (`disableFix`, `severity`, `url`, `reportDisables`, and `message`),
+even though they are not explicitly reflected in the type definitions to avoid unnecessary noise.
+
+---
+
+Note: the `message` option is technically available, but its use is discouraged: each rule already provides a typed [`messages`](#messages) object,
+which not only offers IDE autocompletion but also supports multiline strings and automatically handles indentation.
+
+---
+
+For more information, see the official [Stylelint configuration docs](https://stylelint.io/user-guide/configure/#rules).
+
+:::

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -125,7 +125,7 @@ If you are using JSON or YAML configuration format, this approach will not work 
 
 If you are using the JS configuration format, for a better DX you can use a typed wrapper function to enable rules along with their defaults.
 
-The plugin exports a JS function `createDefineRules`, which provides IDE autocompletion for plugin rules and their options.
+The plugin exports a JS function `createDefineRules`, which provides IDE autocompletion for plugin rules and their options, and also type checking.
 
 ---
 
@@ -146,6 +146,9 @@ With this function, you can avoid duplicating this option in each of those rules
 ### Example configuration with comments
 
 ```js
+// 0. Enable type checking for a JS file (optional)
+// @ts-check
+
 // 1. Import the factory from the plugin.
 import { createDefineRules } from '@morev/stylelint-plugin';
 

--- a/src/modules/meta/types.ts
+++ b/src/modules/meta/types.ts
@@ -168,7 +168,11 @@ export type RuleSetting<Primary, Secondary> =
 	| null
 	| Primary
 	| [null | Primary]
-	| [null | Primary, Secondary & StylelintSecondaryOptions];
+	| [null | Primary, Secondary & { [key: string]: any }];
+	// Note about this:            ↑
+	// The most accurate type is `Secondary & StylelintSecondaryOptions`,
+	// but it feels unnecessarily verbose from the end-user's perspective,
+	// so we just open the door to the common Stylelint properties instead.
 
 /**
  * Global plugin settings that may apply to multiple rules.

--- a/src/modules/meta/types.ts
+++ b/src/modules/meta/types.ts
@@ -2,90 +2,6 @@ import type { Severity } from 'stylelint';
 import type { Separators } from '#modules/shared';
 
 /**
- * Metadata describing a single Stylelint rule within the plugin.
- * Generated automatically from the actual rule sources.
- */
-export type RuleMeta = {
-	/**
-	 * Fully qualified rule ID.
-	 *
-	 * @example '@morev/bem/no-side-effects'
-	 */
-	id: string;
-
-	/**
-	 * Logical scope of the rule.
-	 * Used for grouping and documentation.
-	 *
-	 * @example 'base'
-	 * @example 'bem'
-	 * @example 'sass'
-	 */
-	scope: string;
-
-	/**
-	 * Short name of the rule without namespace or scope.
-	 *
-	 * @example 'no-side-effects'
-	 */
-	name: string;
-
-	/**
-	 * Human-readable description of the rule.
-	 *
-	 * @example 'Disallows selectors that apply styles outside the scope of the current BEM block.'
-	 */
-	description: string;
-
-	/**
-	 * Indicates whether the rule supports auto-fixes.
-	 *
-	 * @example true
-	 */
-	fixable: boolean;
-
-	/**
-	 * Relative path (from repo root) to the rule's documentation file.
-	 *
-	 * @example 'src/rules/bem/no-side-effects/no-side-effects.docs.md'
-	 */
-	docsPath: string;
-
-	/**
-	 * The path used by VitePress to link to the rule's documentation page.
-	 *
-	 * @example '/rules/bem/no-side-effects.md'
-	 */
-	vitepressPath: string;
-
-	/**
-	 * The link to the rule page used by VitePress.
-	 *
-	 * @example '/rules/bem/no-side-effects.html'
-	 */
-	vitepressLink: string;
-};
-
-/**
- * Type helper representing the configuration shape for a single rule.
- */
-export type RuleSetting<Primary, Secondary> =
-	| null
-	| Primary
-	| [null | Primary]
-	| [null | Primary, Secondary];
-
-/**
- * Global plugin settings that may apply to multiple rules.
- */
-export type PluginGlobals = {
-	/**
-	 * Defines the separators used to parse BEM class names.
-	 */
-	separators?: Separators;
-};
-
-/**
  * Types supported by every rule to ensure compatibility with Stylelint.
  *
  * @see https://stylelint.io/user-guide/configure/#rules
@@ -178,4 +94,88 @@ export type StylelintSecondaryOptions = {
 	 * ```
 	 */
 	severity?: Severity | ((...args: any[]) => Severity | null);
+};
+
+/**
+ * Metadata describing a single Stylelint rule within the plugin.
+ * Generated automatically from the actual rule sources.
+ */
+export type RuleMeta = {
+	/**
+	 * Fully qualified rule ID.
+	 *
+	 * @example '@morev/bem/no-side-effects'
+	 */
+	id: string;
+
+	/**
+	 * Logical scope of the rule.
+	 * Used for grouping and documentation.
+	 *
+	 * @example 'base'
+	 * @example 'bem'
+	 * @example 'sass'
+	 */
+	scope: string;
+
+	/**
+	 * Short name of the rule without namespace or scope.
+	 *
+	 * @example 'no-side-effects'
+	 */
+	name: string;
+
+	/**
+	 * Human-readable description of the rule.
+	 *
+	 * @example 'Disallows selectors that apply styles outside the scope of the current BEM block.'
+	 */
+	description: string;
+
+	/**
+	 * Indicates whether the rule supports auto-fixes.
+	 *
+	 * @example true
+	 */
+	fixable: boolean;
+
+	/**
+	 * Relative path (from repo root) to the rule's documentation file.
+	 *
+	 * @example 'src/rules/bem/no-side-effects/no-side-effects.docs.md'
+	 */
+	docsPath: string;
+
+	/**
+	 * The path used by VitePress to link to the rule's documentation page.
+	 *
+	 * @example '/rules/bem/no-side-effects.md'
+	 */
+	vitepressPath: string;
+
+	/**
+	 * The link to the rule page used by VitePress.
+	 *
+	 * @example '/rules/bem/no-side-effects.html'
+	 */
+	vitepressLink: string;
+};
+
+/**
+ * Type helper representing the configuration shape for a single rule.
+ */
+export type RuleSetting<Primary, Secondary> =
+	| null
+	| Primary
+	| [null | Primary]
+	| [null | Primary, Secondary & StylelintSecondaryOptions];
+
+/**
+ * Global plugin settings that may apply to multiple rules.
+ */
+export type PluginGlobals = {
+	/**
+	 * Defines the separators used to parse BEM class names.
+	 */
+	separators?: Separators;
 };

--- a/src/modules/meta/types.ts
+++ b/src/modules/meta/types.ts
@@ -1,3 +1,4 @@
+import type { Severity } from 'stylelint';
 import type { Separators } from '#modules/shared';
 
 /**
@@ -74,9 +75,107 @@ export type RuleSetting<Primary, Secondary> =
 	| [null | Primary]
 	| [null | Primary, Secondary];
 
+/**
+ * Global plugin settings that may apply to multiple rules.
+ */
 export type PluginGlobals = {
 	/**
 	 * Defines the separators used to parse BEM class names.
 	 */
 	separators?: Separators;
+};
+
+/**
+ * Types supported by every rule to ensure compatibility with Stylelint.
+ *
+ * @see https://stylelint.io/user-guide/configure/#rules
+ */
+export type StylelintSecondaryOptions = {
+	/**
+	 * You can set the `disableFix` secondary option to disable autofix on a per-rule basis.
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#disablefix
+	 *
+	 * @example
+	 * ```js
+	 * {
+	 *   rules: {
+	 *     '@morev/bem/selector-pattern': [true, {
+	 *       disableFix: true,
+	 *     }],
+	 *   },
+	 * }
+	 * ```
+	 */
+	disableFix?: boolean;
+
+	/**
+	 * It's best to customize all messages through the `messages` option, which is available in every rule. \
+	 * The option is included to preserve formal alignment with Stylelint's core behavior and is not recommended for use.
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#message
+	 */
+	message?: string | ((...args: any[]) => string);
+
+	/**
+	 * You can use the `url` secondary option to provide a custom link to external docs.
+	 * These urls can then be displayed in custom formatters.
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#url
+	 *
+	 * @example
+	 * ```js
+	 * {
+	 *   rules: {
+	 *     '@morev/bem/selector-pattern': [true, {
+	 *       url: 'https://your-docs.com/guide/how-to-use-bem/',
+	 *     }],
+	 *   },
+	 * }
+	 * ```
+	 */
+	url?: string;
+
+	/**
+	 * You can set the `reportDisables` secondary option to report any `stylelint-disable`
+	 * comments for this rule, effectively disallowing authors to opt-out of it.
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#reportdisables
+	 *
+	 * @example
+	 * ```js
+	 * {
+	 *   rules: {
+	 *     '@morev/bem/selector-pattern': [true, {
+	 *       reportDisables: true,
+	 *     }],
+	 *   },
+	 * }
+	 * ```
+	 */
+	reportDisables?: boolean;
+
+	/**
+	 * You can use the `severity` secondary option to adjust any specific rule's severity. \
+	 * It is possible to use a function for `severity`, which would accept message arguments,
+	 * allowing you to adjust the severity based on these arguments.
+	 *
+	 * The available values for severity are:
+	 * - "warning"
+	 * - "error" (default)
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#severity
+	 *
+	 * @example
+	 * ```js
+	 * {
+	 *   rules: {
+	 *     '@morev/bem/selector-pattern': [true, {
+	 *       severity: 'warning',
+	 *     }],
+	 *   },
+	 * }
+	 * ```
+	 */
+	severity?: Severity | ((...args: any[]) => Severity | null);
 };

--- a/src/modules/rule-utils/create-rule/create-rule.ts
+++ b/src/modules/rule-utils/create-rule/create-rule.ts
@@ -46,8 +46,9 @@ type Callback<
 	},
 ) => void;
 
-type BetterProblem = Omit<Problem, 'node' | 'ruleName' | 'result' | 'line' | 'start'>
+type BetterProblem = Omit<Problem, 'node' | 'ruleName' | 'result' | 'line' | 'start' | 'messageArgs'>
 	& ({
+		messageArgs: [string, ...any[]];
 		node: Problem['node'];
 		index?: Exclude<Problem['index'], undefined>;
 		endIndex?: Exclude<Problem['endIndex'], undefined>;

--- a/src/rules/base/no-selectors-in-at-rules/__tests__/no-selectors-in-at-rules.configuration.test.ts
+++ b/src/rules/base/no-selectors-in-at-rules/__tests__/no-selectors-in-at-rules.configuration.test.ts
@@ -38,10 +38,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.docs.md
+++ b/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.docs.md
@@ -206,6 +206,8 @@ type NoSelectorsInAtRulesOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `ignore`

--- a/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.ts
+++ b/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.ts
@@ -21,7 +21,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				ignore: v.optional(
 					v.objectWithRest(
 						{},

--- a/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.ts
+++ b/src/rules/base/no-selectors-in-at-rules/no-selectors-in-at-rules.ts
@@ -61,6 +61,7 @@ export default createRule({
 
 			report({
 				message: messages.unexpected(node.selector, atRule.name),
+				messageArgs: ['unexpected', node.selector, atRule.name],
 				node,
 				word: node.selector,
 			});

--- a/src/rules/bem/block-variable/__tests__/block-variable.configuration.test.ts
+++ b/src/rules/bem/block-variable/__tests__/block-variable.configuration.test.ts
@@ -34,10 +34,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Not an object option',
 			config: [true, 'always'],
 		},

--- a/src/rules/bem/block-variable/block-variable.docs.md
+++ b/src/rules/bem/block-variable/block-variable.docs.md
@@ -200,6 +200,8 @@ type BlockVariableOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `name`

--- a/src/rules/bem/block-variable/block-variable.ts
+++ b/src/rules/bem/block-variable/block-variable.ts
@@ -19,7 +19,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				name: v.optional(v.string(), 'b'),
 				interpolation: v.optional(v.picklist(['always', 'never', 'ignore']), 'always'),
 				firstChild: v.optional(v.boolean(), true),

--- a/src/rules/bem/block-variable/block-variable.ts
+++ b/src/rules/bem/block-variable/block-variable.ts
@@ -135,6 +135,7 @@ export default createRule({
 		if (variableDeclaration.prop !== VARIABLE_NAME) {
 			report({
 				message: messages.invalidVariableName(VARIABLE_NAME, variableDeclaration.prop),
+				messageArgs: ['invalidVariableName', VARIABLE_NAME, variableDeclaration.prop],
 				node: variableDeclaration,
 				fix: () => {
 					variableDeclaration.prop = VARIABLE_NAME;
@@ -147,6 +148,7 @@ export default createRule({
 	if (allBlockVariableDeclarations.length === 0) {
 		report({
 			message: messages.missingVariable(VARIABLE_NAME),
+			messageArgs: ['missingVariable', VARIABLE_NAME],
 			node: bemBlock.rule,
 			word: bemBlock.selector,
 			fix: () => {
@@ -185,6 +187,7 @@ export default createRule({
 
 			report({
 				message: messages.duplicatedVariable(declaration.prop, VARIABLE_NAME),
+				messageArgs: ['duplicatedVariable', declaration.prop, VARIABLE_NAME],
 				node: declaration,
 			});
 		});
@@ -194,6 +197,7 @@ export default createRule({
 	if (validBlockVariable?.value && !VALID_VALUES.includes(validBlockVariable.value)) {
 		return report({
 			message: messages.invalidVariableValue(validBlockVariable.value, VALID_VALUES),
+			messageArgs: ['invalidVariableValue', validBlockVariable.value, VALID_VALUES],
 			node: validBlockVariable,
 			fix: () => {
 				validBlockVariable.value = VALID_VALUES[0];
@@ -208,6 +212,7 @@ export default createRule({
 	) {
 		report({
 			message: messages.variableNotFirst(VARIABLE_NAME, bemBlock.rule.selector),
+			messageArgs: ['variableNotFirst', VARIABLE_NAME, bemBlock.rule.selector],
 			node: validBlockVariable,
 			fix: () => {
 				bemBlock.rule.prepend(validBlockVariable.clone());
@@ -259,6 +264,7 @@ export default createRule({
 						context,
 						fixable,
 					),
+					messageArgs: ['hardcodedBlockName', bemBlock.selector, variableRef, context, fixable],
 					node: rule,
 					index: node.sourceIndex,
 					endIndex: node.sourceIndex + bemBlock.selector.length,

--- a/src/rules/bem/match-file-name/__tests__/match-file-name.configuration.test.ts
+++ b/src/rules/bem/match-file-name/__tests__/match-file-name.configuration.test.ts
@@ -39,10 +39,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},
@@ -71,10 +67,6 @@ testRuleConfig({
 			description: 'Unknown option type',
 			config: [true, { caseSensitive: 'yes' }],
 		},
-		{
-			description: 'Unknown additional option',
-			config: [true, { caseSensitive: true, foo: 'bar' }],
-		},
 	],
 });
 
@@ -99,10 +91,6 @@ testRuleConfig({
 		{
 			description: 'Unknown option type',
 			config: [true, { matchDirectory: 'yes' }],
-		},
-		{
-			description: 'Unknown additional option',
-			config: [true, { matchDirectory: true, foo: 'bar' }],
 		},
 	],
 });

--- a/src/rules/bem/match-file-name/match-file-name.docs.md
+++ b/src/rules/bem/match-file-name/match-file-name.docs.md
@@ -87,6 +87,65 @@ export default {
 
 :::
 
+::: details Show full type of the options
+
+```ts
+export type MatchFileNameOptions = {
+  /**
+   * Whether the comparison should be case-sensitive.
+   *
+   * If `true`, the file or directory name must match the block name exactly,
+   * including character case. If `false`, case is ignored.
+   *
+   * @default true
+   */
+  caseSensitive?: boolean;
+
+  /**
+   * Whether to use the name of the containing directory instead of the file name
+   * for block name comparison.
+   *
+   * This is useful when using a folder-based structure like:
+   * `/components/the-component/index.scss`
+   *
+   * @default false
+   */
+  matchDirectory?: boolean;
+
+  /**
+   * Custom message functions for rule violations.
+   * If provided, overrides the default error messages.
+   */
+  messages?: {
+    /**
+     * Custom message for when the name does not match the block name.
+     *
+     * @param   entity      Either `'file'` or `'directory'`, depending on which name is being checked.
+     * @param   blockName   The name of the BEM block.
+     *
+     * @returns             The error message to report.
+     */
+    match?: (entity: 'file' | 'directory', blockName: string) => string;
+
+    /**
+     * Custom message for when the name matches the block name structurally
+     * but fails due to case mismatch (if `caseSensitive: true`).
+     *
+     * @param   entity      Either `'file'` or `'directory'`, depending on which name is being checked.
+     * @param   blockName   The name of the BEM block.
+     *
+     * @returns             The error message to report.
+     */
+    matchCase?: (entity: 'file' | 'directory', blockName: string) => string;
+  };
+};
+
+```
+
+:::
+
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `caseSensitive`

--- a/src/rules/bem/match-file-name/match-file-name.ts
+++ b/src/rules/bem/match-file-name/match-file-name.ts
@@ -21,7 +21,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				caseSensitive: v.optional(v.boolean(), true),
 				matchDirectory: v.optional(v.boolean(), false),
 				messages: vMessagesSchema({

--- a/src/rules/bem/match-file-name/match-file-name.ts
+++ b/src/rules/bem/match-file-name/match-file-name.ts
@@ -52,6 +52,7 @@ export default createRule({
 	const reportType = (type: 'match' | 'matchCase') => {
 		report({
 			message: messages[type](entity, bemBlock.blockName),
+			messageArgs: [type, entity, bemBlock.blockName],
 			node: bemBlock.rule,
 			index: 0,
 			endIndex: 1,

--- a/src/rules/bem/no-block-properties/__tests__/no-block-properties.configuration.test.ts
+++ b/src/rules/bem/no-block-properties/__tests__/no-block-properties.configuration.test.ts
@@ -38,10 +38,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/bem/no-block-properties/no-block-properties.docs.md
+++ b/src/rules/bem/no-block-properties/no-block-properties.docs.md
@@ -257,6 +257,8 @@ export type NoBlockPropertiesOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `presets`

--- a/src/rules/bem/no-block-properties/no-block-properties.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.ts
@@ -132,13 +132,21 @@ export default createRule({
 						.map(({ declaration }) => declaration);
 
 					declarationsToReport.forEach((declaration) => {
+						const presetName = propertyToPresetMap.get(declaration.prop);
 						report({
 							message: messages.unexpected(
 								declaration.prop,
 								bemEntity.bemSelector,
 								context,
-								propertyToPresetMap.get(declaration.prop),
+								presetName,
 							),
+							messageArgs: [
+								'unexpected',
+								declaration.prop,
+								bemEntity.bemSelector,
+								context,
+								presetName,
+							],
 							node: declaration,
 							word: declaration.prop,
 						});

--- a/src/rules/bem/no-block-properties/no-block-properties.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.ts
@@ -39,7 +39,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				presets: v.optional(
 					v.array(v.string()),
 					['EXTERNAL_GEOMETRY'],

--- a/src/rules/bem/no-chained-entities/__tests__/no-chained-entities.configuration.test.ts
+++ b/src/rules/bem/no-chained-entities/__tests__/no-chained-entities.configuration.test.ts
@@ -38,10 +38,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/bem/no-chained-entities/no-chained-entities.docs.md
+++ b/src/rules/bem/no-chained-entities/no-chained-entities.docs.md
@@ -240,6 +240,8 @@ export type NoChainedEntitiesSecondaryOption = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `disallowNestedModifierValues`

--- a/src/rules/bem/no-chained-entities/no-chained-entities.ts
+++ b/src/rules/bem/no-chained-entities/no-chained-entities.ts
@@ -186,7 +186,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				disallowNestedModifierValues: v.optional(v.boolean(), false),
 				separators: vSeparatorsSchema,
 				messages: vMessagesSchema({

--- a/src/rules/bem/no-chained-entities/no-chained-entities.ts
+++ b/src/rules/bem/no-chained-entities/no-chained-entities.ts
@@ -212,6 +212,7 @@ export default createRule({
 		report({
 			...violation,
 			message: messages[violation.type](violation.actual, violation.expected),
+			messageArgs: [violation.type, violation.actual, violation.expected],
 		});
 	});
 });

--- a/src/rules/bem/no-side-effects/__tests__/no-side-effects.configuration.test.ts
+++ b/src/rules/bem/no-side-effects/__tests__/no-side-effects.configuration.test.ts
@@ -38,10 +38,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/bem/no-side-effects/no-side-effects.docs.md
+++ b/src/rules/bem/no-side-effects/no-side-effects.docs.md
@@ -108,6 +108,8 @@ export type NoSideEffectsOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `ignore`

--- a/src/rules/bem/no-side-effects/no-side-effects.ts
+++ b/src/rules/bem/no-side-effects/no-side-effects.ts
@@ -22,7 +22,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				ignore: v.optional(v.array(vStringOrRegExpSchema), []),
 				messages: vMessagesSchema({
 					rejected: [v.string()],

--- a/src/rules/bem/no-side-effects/no-side-effects.ts
+++ b/src/rules/bem/no-side-effects/no-side-effects.ts
@@ -77,5 +77,6 @@ export default createRule({
 	getViolations().forEach((violation) => report({
 		...violation,
 		message: messages.rejected(violation.selector),
+		messageArgs: ['rejected', violation.selector],
 	}));
 });

--- a/src/rules/bem/selector-pattern/__tests__/selector-pattern.configuration.test.ts
+++ b/src/rules/bem/selector-pattern/__tests__/selector-pattern.configuration.test.ts
@@ -38,10 +38,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/bem/selector-pattern/selector-pattern.docs.md
+++ b/src/rules/bem/selector-pattern/selector-pattern.docs.md
@@ -212,6 +212,8 @@ type BemPatternOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ### `patterns`
 
 All of the keys of `patterns` property define the allowed naming patterns

--- a/src/rules/bem/selector-pattern/selector-pattern.ts
+++ b/src/rules/bem/selector-pattern/selector-pattern.ts
@@ -127,18 +127,20 @@ export default createRule({
 						value: entityPart.value,
 						// Intentionally loosened type for modifier values scenario (might be `false`)
 						message: messages[entityType](entityPart.value, bemEntity.bemSelector, entityPatterns as any),
+						messageArgs: [entityType, entityPart.value, bemEntity.bemSelector, entityPatterns as any],
 					});
 				});
 			});
 		});
 	});
 
-	violations.forEach(({ rule, entityPart, message }) => {
+	violations.forEach(({ rule, entityPart, message, messageArgs }) => {
 		report({
 			node: rule,
 			index: entityPart.sourceRange?.[0] ?? 0,
 			endIndex: entityPart.sourceRange?.[1] ?? rule.toString().length,
 			message,
+			messageArgs,
 		});
 	});
 });

--- a/src/rules/bem/selector-pattern/selector-pattern.ts
+++ b/src/rules/bem/selector-pattern/selector-pattern.ts
@@ -32,7 +32,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				patterns: v.optional(
 					v.strictObject({
 						block: v.optional(

--- a/src/rules/bem/selector-pattern/utils/create-violations-registry/create-violations-registry.ts
+++ b/src/rules/bem/selector-pattern/utils/create-violations-registry/create-violations-registry.ts
@@ -7,6 +7,7 @@ type Violation = {
 	selector: string;
 	value: string;
 	message: string;
+	messageArgs: [string, ...any[]];
 };
 
 export const createViolationsRegistry = () => {

--- a/src/rules/sass/no-unused-variables/__tests__/no-unused-variables.configuration.test.ts
+++ b/src/rules/sass/no-unused-variables/__tests__/no-unused-variables.configuration.test.ts
@@ -36,10 +36,6 @@ testRuleConfig({
 	],
 	reject: [
 		{
-			description: 'Unknown option',
-			config: [true, { foo: 'bar' }],
-		},
-		{
 			description: 'Secondary is not an object',
 			config: [true, 'always'],
 		},

--- a/src/rules/sass/no-unused-variables/no-unused-variables.docs.md
+++ b/src/rules/sass/no-unused-variables/no-unused-variables.docs.md
@@ -102,6 +102,8 @@ type NoUnusedVariablesOptions = {
 
 :::
 
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
 ---
 
 ### `checkRoot`

--- a/src/rules/sass/no-unused-variables/no-unused-variables.ts
+++ b/src/rules/sass/no-unused-variables/no-unused-variables.ts
@@ -179,6 +179,7 @@ export default createRule({
 
 			report({
 				message: messages.unused(name),
+				messageArgs: ['unused', name],
 				node: declaration,
 			});
 		});

--- a/src/rules/sass/no-unused-variables/no-unused-variables.ts
+++ b/src/rules/sass/no-unused-variables/no-unused-variables.ts
@@ -49,7 +49,7 @@ export default createRule({
 	schema: {
 		primary: v.literal(true),
 		secondary: v.optional(
-			v.strictObject({
+			v.object({
 				checkRoot: v.optional(v.boolean(), false),
 				ignore: v.optional(v.array(vStringOrRegExpSchema), []),
 				messages: vMessagesSchema({


### PR DESCRIPTION
#### Description

This PR introduces full support for Stylelint per-rule secondary options across all plugin rules.
This is mentioned in the documentation, and the types for `createDefineConfig` have also been extended. The only difference is that they don't enumerate the full type of all these options, since that's rarely needed and in 99% of cases would just add noise. Instead, the capability is left available through an index signature.

In addition, `messageArgs` was added for compatibility with the Stylelint core - although `message` customization already exists and is recommended via the `messages` option, the `severity` option can also be a function.

#### Linked issue

Closes #9