### PR TITLE
fix(no-chained-entities): Prevent error during live input

### DIFF
--- a/src/rules/bem/no-chained-entities/__tests__/no-chained-entities.implementation.test.ts
+++ b/src/rules/bem/no-chained-entities/__tests__/no-chained-entities.implementation.test.ts
@@ -87,6 +87,16 @@ testRule({
 				}
 			`,
 		},
+		{
+			description: 'Does not warn in case of incomplete input',
+			code: `
+				.the-component {
+					&__element {
+						&- {}
+					}
+				}
+			`,
+		},
 	],
 	reject: [
 		{

--- a/src/rules/bem/no-chained-entities/no-chained-entities.ts
+++ b/src/rules/bem/no-chained-entities/no-chained-entities.ts
@@ -1,4 +1,3 @@
-import { assert } from '@morev/utils';
 import * as v from 'valibot';
 import { resolveBemChain } from '#modules/bem';
 import { getRuleContentMeta, isAtRule, isRule } from '#modules/postcss';
@@ -116,6 +115,10 @@ const getViolationsFromGroups = (
 		const { repeating: [deepestEntity], nextPart } = group;
 		const { type, part } = deepestEntity;
 
+		// Prevent processing of incomplete input
+		// https://github.com/MorevM/stylelint-plugin/issues/17
+		if (!deepestEntity.part.sourceRange) continue;
+
 		const [index, endIndex] = part.sourceRange ?? [0, 0];
 		const key = `${index}-${endIndex}-${part.selector}`;
 
@@ -125,11 +128,6 @@ const getViolationsFromGroups = (
 		seen.add(key);
 
 		const actual = (() => {
-			assert(
-				deepestEntity.part.sourceRange,
-				'`deepestEntity` should have a `sourceRange` here.',
-			);
-
 			const { raw: source } = getRuleContentMeta(deepestEntity.rule);
 			const actual = source.slice(...deepestEntity.part.sourceRange);
 


### PR DESCRIPTION
#### Description

This PR fixes the bug described in #17.
It's actually a parser bug when calculating indexes, but it will be reworked soon anyway, so this is just a patch.
