### PR TITLE
chore: Proper usage of nested custom containers

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -28,7 +28,7 @@ for consistency with the BEM-specific rules.
 - Create the [`.stylelintrc` config file](https://stylelint.io/user-guide/configure/) *(or open the existing one)*;
 - Add `@morev/stylelint-plugin` to the [`plugins`](https://stylelint.io/user-guide/configure/#plugins) array;
 
-::: details Show example
+:::: details Show example
 
 ::: code-group
 
@@ -43,10 +43,12 @@ export default {
 
 :::
 
+::::
+
 - Add the general rules from the `base` and `sass` categories to the [`overrides`] array
   (or directly to the `rules` object - it's safe to do so);
 
-::: details Show example
+:::: details Show example
 
 ::: code-group
 
@@ -85,6 +87,8 @@ export default {
 ```
 
 :::
+
+::::
 
 - Add the rules from the `bem` category under `overrides`, using the `files` field to restrict them to the exact paths of BEM components
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,12 +5,7 @@ export default combine([
 	defineConfiguration('javascript'),
 	defineConfiguration('node'),
 	defineConfiguration('json'),
-	defineConfiguration('markdown', {
-		overrides: {
-			// https://github.com/ota-meshi/eslint-plugin-markdown-preferences/issues/256
-			'markdown-preferences/no-implicit-block-closing': 'off',
-		},
-	}),
+	defineConfiguration('markdown'),
 	defineConfiguration('yaml'),
 	defineConfiguration('html'),
 	defineConfiguration('vitest', {

--- a/src/rules/bem/no-block-properties/no-block-properties.docs.md
+++ b/src/rules/bem/no-block-properties/no-block-properties.docs.md
@@ -288,7 +288,7 @@ using [`customPresets`](#custompresets) option if needed.
 | `CONTEXT`           | Properties that influence layout behavior within a parent container.        |
 | `POSITIONING`       | Properties related to absolute or relative positioning of the block itself. |
 
-::: details Show properties list
+:::: details Show properties list
 
 ```ts
 const BUILTIN_PRESETS = {
@@ -327,8 +327,9 @@ const BUILTIN_PRESETS = {
 ::: info Note
 The exact property lists are defined by the plugin and may be expanded in future versions
 following [Semantic Versioning](https://semver.org/) specification.
-
 :::
+
+::::
 
 
 #### Behavior
@@ -791,6 +792,6 @@ export type MessagesOption = {
 
 :::
 
-[`presets`]: #presets
-
 <!-- @include: @/docs/_parts/custom-messages.md#formatting -->
+
+[`presets`]: #presets

--- a/src/rules/bem/selector-pattern/selector-pattern.docs.md
+++ b/src/rules/bem/selector-pattern/selector-pattern.docs.md
@@ -305,7 +305,7 @@ import {
 
 :::
 
-::: details `RegExp`
+:::: details `RegExp`
 
 A regular expression for advanced matching, if the configuration format allows it. \
 For example, `yaml` and `json` configurations do not support direct `RegExp` usage -
@@ -353,8 +353,9 @@ import {
   SNAKE_CASE_NUMERIC_REGEXP,
 } from '@morev/stylelint-plugin/constants';
 ```
-
 :::
+
+::::
 
 ::: details `array`
 
@@ -453,7 +454,7 @@ and validated against `pattern.modifierName`.
 
 #### Configuration examples
 
-::: details `Two Dashes` style (default)
+:::: details `Two Dashes` style (default)
 
 ::: code-group
 
@@ -484,7 +485,9 @@ export default {
 
 :::
 
-::: details `Traditional` style
+::::
+
+:::: details `Traditional` style
 
 ::: code-group
 
@@ -515,8 +518,9 @@ export default {
 
 :::
 
+::::
 
-::: details `React` style
+:::: details `React` style
 
 ::: code-group
 
@@ -546,6 +550,8 @@ export default {
 ```
 
 :::
+
+::::
 
 <!-- @include: @/docs/_parts/separators.md#footer -->
 


### PR DESCRIPTION
Nested containers should use more than 3 colons in case of nesting, just like code blocks.
https://github.com/ota-meshi/eslint-plugin-markdown-preferences/issues/256#issuecomment-3937974988