### PR TITLE
ci: Check docs build on pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,19 @@ jobs:
       - name: Linting
         run: pnpm lint
 
+  docs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Build docs
+        run: pnpm docs:build
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Security fixes are released as **patch** versions on the latest **minor** line. 
 
 Do **not** open public issues for security problems. Use one of the private channels:
 
-- **GitHub Security Advisory**: [create a private report](./security/advisories/new)
+- **GitHub Security Advisory**: [create a private report](https://github.com/MorevM/stylelint-plugin/security/advisories/new)
 - **Email**: [max.seainside@gmail.com](mailto:max.seainside@gmail.com)
 
 A report should include description, impact, reproduction steps, and affected versions. \


### PR DESCRIPTION
Fixes a broken link in SECURITY.md found during the `VitePress` build and prevents similar issues in the future by including documentation build as part of the PR review process.