### PR TITLE
feat: Exact types for `createDefineRules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"@morev/utils": "^3.15.0",
 		"postcss": "^8.5.16",
 		"postcss-selector-parser": "^7.1.4",
+		"type-fest": "^4.41.0",
 		"valibot": "^1.4.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": false,
 	"version": "0.5.0",
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"license": "MIT",
 	"publishConfig": {
@@ -82,7 +82,7 @@
 		"@morev/utils": "^3.15.0",
 		"postcss": "^8.5.16",
 		"postcss-selector-parser": "^7.1.4",
-		"type-fest": "^4.41.0",
+		"type-fest": "^5.8.0",
 		"valibot": "^1.4.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^7.1.4
         version: 7.1.4
       type-fest:
-        specifier: ^4.41.0
-        version: 4.41.0
+        specifier: ^5.8.0
+        version: 5.8.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)
@@ -5698,6 +5698,10 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -5863,6 +5867,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -12222,6 +12230,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.3.0: {}
 
   text-extensions@1.9.0: {}
@@ -12350,6 +12360,10 @@ snapshots:
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       postcss-selector-parser:
         specifier: ^7.1.4
         version: 7.1.4
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)

--- a/src/create-define-rules/create-define-rules.test.ts
+++ b/src/create-define-rules/create-define-rules.test.ts
@@ -4,6 +4,8 @@ import {
 } from '#modules/test-utils';
 import { createDefineRules } from './create-define-rules';
 
+const autocompleteTestTimeoutMs = 10_000;
+
 describe(createDefineRules, () => {
 	it('Allows omitted globals and rules arguments', () => {
 		const defineRules = createDefineRules();
@@ -208,7 +210,7 @@ describe(createDefineRules, () => {
 			`);
 
 			expect(completions).toContain('separators');
-		});
+		}, autocompleteTestTimeoutMs);
 
 		it('Suggests separator options', () => {
 			const completions = getTypeScriptCompletionNames(`
@@ -224,7 +226,7 @@ describe(createDefineRules, () => {
 				'modifier',
 				'modifierValue',
 			]));
-		});
+		}, autocompleteTestTimeoutMs);
 
 		it('Suggests rule names', () => {
 			const completions = getTypeScriptCompletionNames(`
@@ -242,7 +244,7 @@ describe(createDefineRules, () => {
 				'globals',
 				'rules',
 			]));
-		});
+		}, autocompleteTestTimeoutMs);
 
 		it('Suggests rule secondary options', () => {
 			const completions = getTypeScriptCompletionNames(`
@@ -269,6 +271,6 @@ describe(createDefineRules, () => {
 				'severity',
 				'url',
 			]));
-		});
+		}, autocompleteTestTimeoutMs);
 	});
 });

--- a/src/create-define-rules/create-define-rules.test.ts
+++ b/src/create-define-rules/create-define-rules.test.ts
@@ -1,0 +1,274 @@
+import {
+	getTypeScriptCompletionNames,
+	typeScriptCompletionMarker,
+} from '#modules/test-utils';
+import { createDefineRules } from './create-define-rules';
+
+describe(createDefineRules, () => {
+	it('Allows omitted globals and rules arguments', () => {
+		const defineRules = createDefineRules();
+
+		const rules = defineRules();
+
+		expect(rules).toStrictEqual({});
+
+		expectTypeOf<keyof typeof rules>().toEqualTypeOf<never>();
+	});
+
+	it('Preserves exact rule names and normalized rule values', () => {
+		const defineRules = createDefineRules({});
+
+		const rules = defineRules({
+			'@morev/sass/no-unused-variables': [true, {
+				checkRoot: true,
+				ignore: ['b'],
+			}],
+		});
+
+		expectTypeOf<keyof typeof rules>().toEqualTypeOf<'@morev/sass/no-unused-variables'>();
+		expectTypeOf(rules).not.toHaveProperty('@morev/bem/block-variable');
+		expectTypeOf(rules['@morev/sass/no-unused-variables']).toEqualTypeOf<[
+			true,
+			{
+				checkRoot: true;
+				ignore: ['b'];
+			},
+		]>();
+	});
+
+	it('Preserves exact rule names from const object literals', () => {
+		const defineRules = createDefineRules({});
+
+		const rules = defineRules({
+			'@morev/sass/no-unused-variables': [true, { checkRoot: true }],
+		} as const);
+
+		expectTypeOf<keyof typeof rules>().toEqualTypeOf<'@morev/sass/no-unused-variables'>();
+		expectTypeOf(rules['@morev/sass/no-unused-variables']).toEqualTypeOf<[
+			true,
+			{ checkRoot: true },
+		]>();
+	});
+
+	it('Allows arbitrary secondary options without typing them explicitly', () => {
+		const defineRules = createDefineRules({});
+
+		const rules = defineRules({
+			'@morev/bem/block-variable': [true, {
+				firstChild: true,
+				severity: 'warning',
+			}],
+		});
+
+		expectTypeOf(rules['@morev/bem/block-variable']).toEqualTypeOf<[
+			true,
+			{
+				firstChild: true;
+				severity: 'warning';
+				separators: undefined;
+			},
+		]>();
+	});
+
+	it('Accepts partial global separators', () => {
+		const defineRules = createDefineRules({
+			separators: {
+				element: '__',
+			},
+		});
+
+		const rules = defineRules({
+			'@morev/bem/block-variable': [true, { firstChild: true }],
+		});
+
+		expectTypeOf(rules['@morev/bem/block-variable']).toEqualTypeOf<[
+			true,
+			{
+				firstChild: true;
+				separators: {
+					readonly element: '__';
+				};
+			},
+		]>();
+	});
+
+	it('Reflects global separators in BEM rule values', () => {
+		const separators = {
+			element: '__',
+			modifier: '--',
+			modifierValue: '_',
+		} as const;
+
+		const defineRules = createDefineRules({ separators });
+
+		const rules = defineRules({
+			'@morev/bem/block-variable': [true, { firstChild: true }],
+		});
+
+		expect(rules).toStrictEqual({
+			'@morev/bem/block-variable': [true, {
+				firstChild: true,
+				separators,
+			}],
+		});
+
+		expectTypeOf<keyof typeof rules>().toEqualTypeOf<'@morev/bem/block-variable'>();
+		expectTypeOf(rules['@morev/bem/block-variable']).toEqualTypeOf<[
+			true,
+			{
+				firstChild: true;
+				separators: typeof separators;
+			},
+		]>();
+	});
+
+	it('Reflects omitted global separators in BEM rule values', () => {
+		const defineRules = createDefineRules();
+
+		const rules = defineRules({
+			'@morev/bem/block-variable': [true, { firstChild: true }],
+		});
+
+		expect(rules).toStrictEqual({
+			'@morev/bem/block-variable': [true, {
+				firstChild: true,
+				separators: undefined,
+			}],
+		});
+
+		expectTypeOf(rules['@morev/bem/block-variable']).toEqualTypeOf<[
+			true,
+			{
+				firstChild: true;
+				separators: undefined;
+			},
+		]>();
+	});
+
+	describe('Diagnostics', () => {
+		it('Rejects unknown rule names', () => {
+			const defineRules = createDefineRules({});
+
+			expect(defineRules).toBeTypeOf('function');
+
+			defineRules({
+				// @ts-expect-error Unknown plugin rule names are rejected.
+				'@morev/unknown/rule': true,
+			});
+		});
+
+		it('Rejects invalid secondary options', () => {
+			const defineRules = createDefineRules({});
+
+			expect(defineRules).toBeTypeOf('function');
+
+			defineRules({
+				// @ts-expect-error `firstChild` accepts a boolean value.
+				'@morev/bem/block-variable': [true, { firstChild: 'true' }],
+			});
+		});
+
+		it('Rejects plugin config objects in rules', () => {
+			const defineRules = createDefineRules({});
+
+			expect(defineRules).toBeTypeOf('function');
+
+			defineRules({
+				// @ts-expect-error `defineRules` accepts a direct rule map, not a plugin config object.
+				globals: {},
+				// @ts-expect-error `defineRules` accepts a direct rule map, not a plugin config object.
+				rules: {},
+			});
+		});
+
+		it('Rejects unknown global options', () => {
+			// @ts-expect-error Unknown plugin global options are rejected.
+			const defineRules = createDefineRules({ unknown: true });
+
+			expect(defineRules).toBeTypeOf('function');
+		});
+
+		it('Rejects invalid global separators', () => {
+			// @ts-expect-error Unknown separator options are rejected.
+			const defineRulesWithUnknownSeparator = createDefineRules({ separators: { unknown: '__' } });
+			// @ts-expect-error Separator options accept string values.
+			const defineRulesWithInvalidSeparator = createDefineRules({ separators: { element: true } });
+
+			expect(defineRulesWithUnknownSeparator).toBeTypeOf('function');
+			expect(defineRulesWithInvalidSeparator).toBeTypeOf('function');
+		});
+	});
+
+	describe('Autocompletion', () => {
+		it('Suggests global options', () => {
+			const completions = getTypeScriptCompletionNames(`
+				import { createDefineRules } from './src/create-define-rules';
+
+				createDefineRules({ ${typeScriptCompletionMarker} });
+			`);
+
+			expect(completions).toContain('separators');
+		});
+
+		it('Suggests separator options', () => {
+			const completions = getTypeScriptCompletionNames(`
+				import { createDefineRules } from './src/create-define-rules';
+
+				createDefineRules({
+					separators: { ${typeScriptCompletionMarker} },
+				});
+			`);
+
+			expect(completions).toStrictEqual(expect.arrayContaining([
+				'element',
+				'modifier',
+				'modifierValue',
+			]));
+		});
+
+		it('Suggests rule names', () => {
+			const completions = getTypeScriptCompletionNames(`
+				import { createDefineRules } from './src/create-define-rules';
+
+				const defineRules = createDefineRules({});
+				defineRules({ ${typeScriptCompletionMarker} });
+			`);
+
+			expect(completions).toStrictEqual(expect.arrayContaining([
+				'"@morev/bem/block-variable"',
+				'"@morev/sass/no-unused-variables"',
+			]));
+			expect(completions).not.toStrictEqual(expect.arrayContaining([
+				'globals',
+				'rules',
+			]));
+		});
+
+		it('Suggests rule secondary options', () => {
+			const completions = getTypeScriptCompletionNames(`
+				import { createDefineRules } from './src/create-define-rules';
+
+				const defineRules = createDefineRules({});
+				defineRules({
+					'@morev/bem/block-variable': [true, { ${typeScriptCompletionMarker} }],
+				});
+			`);
+
+			expect(completions).toStrictEqual(expect.arrayContaining([
+				'firstChild',
+				'interpolation',
+				'messages',
+				'name',
+				'replaceBlockName',
+				'separators',
+			]));
+			expect(completions).not.toStrictEqual(expect.arrayContaining([
+				'disableFix',
+				'message',
+				'reportDisables',
+				'severity',
+				'url',
+			]));
+		});
+	});
+});

--- a/src/create-define-rules/create-define-rules.ts
+++ b/src/create-define-rules/create-define-rules.ts
@@ -1,22 +1,15 @@
 import { toArray, tsObject } from '@morev/utils';
 import type { PluginGlobals, RulesSchema } from '#modules/meta';
+import type {
+	CreateDefineRules,
+	DefineRulesFunction,
+	DefineRulesInput,
+	DefineRulesResult,
+	EmptyInput,
+	ExactRulesInput,
+	PluginConfig,
+} from './create-define-rules.types';
 
-/**
- * Configuration object for the plugin.
- */
-type PluginConfig = {
-	/**
-	 * Global options for the plugin that may affect multiple rules.
-	 */
-	globals?: PluginGlobals;
-
-	/**
-	 * A set of rules with their options.
-	 */
-	rules?: Partial<RulesSchema>;
-};
-
-// @keep-sorted
 const rulesWithSeparators = [
 	'@morev/bem/block-variable',
 	'@morev/bem/match-file-name',
@@ -24,14 +17,19 @@ const rulesWithSeparators = [
 	'@morev/bem/no-chained-entities',
 	'@morev/bem/no-side-effects',
 	'@morev/bem/selector-pattern',
-];
+] as const satisfies ReadonlyArray<keyof RulesSchema>;
 
-const defineRules = (schema: PluginConfig) => {
+type RuleWithSeparators = (typeof rulesWithSeparators)[number];
+
+const defineRules = <
+	const Globals extends PluginGlobals = EmptyInput,
+	const Rules extends DefineRulesInput = EmptyInput,
+>(schema: PluginConfig<Globals, Rules>): DefineRulesResult<Rules, Globals> => {
 	return tsObject.fromEntries(
 		tsObject.entries(schema.rules ?? {}).map(([key, value_]) => {
 			const value = toArray(value_);
 			const primary = value[0];
-			const secondary = value[1] as any;
+			const secondary = value[1] as Record<string, unknown> | undefined;
 
 			const options = { ...secondary };
 
@@ -41,7 +39,7 @@ const defineRules = (schema: PluginConfig) => {
 
 			return [key, [primary, options]];
 		}),
-	);
+	) as DefineRulesResult<Rules, Globals>;
 };
 
 /**
@@ -69,7 +67,7 @@ const defineRules = (schema: PluginConfig) => {
  *
  * @returns           A function that accepts a `RulesSchema` object and returns a normalized rules config.
  */
-export const createDefineRules = (globals: PluginGlobals) => {
+const createDefineRules = (<const Globals extends PluginGlobals = EmptyInput>(globals?: Globals) => {
 	/**
 	 * Defines Stylelint rules with type-safe options and applied globals.
 	 *
@@ -77,5 +75,13 @@ export const createDefineRules = (globals: PluginGlobals) => {
 	 *
 	 * @returns         A normalized rules object ready for Stylelint configuration.
 	 */
-	return (rules: Partial<RulesSchema>) => defineRules({ globals, rules });
-};
+	return (<const Rules extends DefineRulesInput = EmptyInput>(
+		rules?: ExactRulesInput<Rules>,
+	): DefineRulesResult<Rules, Globals> => {
+		return defineRules<Globals, Rules>({ globals, rules });
+	}) as DefineRulesFunction<Globals>;
+}) as CreateDefineRules;
+
+export { createDefineRules };
+
+export type { RuleWithSeparators };

--- a/src/create-define-rules/create-define-rules.types.ts
+++ b/src/create-define-rules/create-define-rules.types.ts
@@ -1,0 +1,163 @@
+import type { ReadonlyDeep, Simplify, WritableDeep } from 'type-fest';
+import type { PluginGlobals, RulesSchema } from '#modules/meta';
+import type { RuleWithSeparators } from './create-define-rules';
+
+/**
+ * Empty object shape used as a default when globals or rules are omitted.
+ */
+type EmptyInput = Record<never, never>;
+
+/**
+ * Converts tuple-based rule settings to their readonly input form while keeping
+ * secondary options deeply readonly for object literal inference.
+ */
+type ReadonlyRuleSetting<Rule> =
+	Rule extends readonly [infer Primary, infer Secondary] ? readonly [Primary, ReadonlyDeep<Secondary>]
+		: Rule extends readonly [infer Primary] ? readonly [Primary]
+			: Rule;
+
+/**
+ * Type accepted by `defineRules`, keyed by all rule names known to the plugin.
+ */
+type DefineRulesInput = {
+	readonly [RuleName in keyof RulesSchema]?: ReadonlyRuleSetting<RulesSchema[RuleName]>;
+};
+
+/**
+ * Plugin globals with excess-property validation for object literals.
+ */
+type ExactPluginGlobals<Globals extends PluginGlobals> =
+	Globals & PluginGlobals & Record<Exclude<keyof Globals, keyof PluginGlobals>, never>;
+
+/**
+ * Rule map input that preserves the exact keys inferred from the user object
+ * while rejecting keys that are not present in `RulesSchema`.
+ */
+type ExactRulesInput<Rules extends object> =
+	DefineRulesInput & Rules & {
+		readonly [RuleName in keyof Rules]: RuleName extends keyof RulesSchema ? DefineRulesInput[RuleName] : never;
+	};
+
+/**
+ * Runtime schema consumed by the internal normalizer.
+ */
+type PluginConfig<Globals extends PluginGlobals, Rules extends DefineRulesInput> = {
+	/**
+	 * Global options for the plugin that may affect multiple rules.
+	 */
+	globals?: Globals;
+
+	/**
+	 * A set of rules with their options.
+	 */
+	rules?: Rules;
+};
+
+/**
+ * Separators inferred from the globals passed to `createDefineRules`.
+ */
+type GlobalSeparators<Globals extends PluginGlobals> =
+	'separators' extends keyof Globals ? Globals['separators'] : undefined;
+
+/**
+ * Secondary options after runtime normalization.
+ *
+ * Rules that consume BEM separators receive separators from plugin globals;
+ * all other rules keep their secondary options as writable output objects.
+ */
+type NormalizedRuleOptions<
+	RuleName,
+	Secondary,
+	Globals extends PluginGlobals,
+> = RuleName extends RuleWithSeparators
+	? Simplify<Omit<WritableDeep<Secondary>, 'separators'> & { separators: GlobalSeparators<Globals> }>
+	: WritableDeep<Secondary>;
+
+/**
+ * Normalized two-item rule tuple returned by `defineRules`.
+ */
+type NormalizeRuleSettingWithGlobals<
+	Rule,
+	RuleName,
+	Globals extends PluginGlobals,
+> =
+	Rule extends null ? [null, NormalizedRuleOptions<RuleName, EmptyInput, Globals>]
+		: Rule extends readonly [infer Primary] ? [Primary, NormalizedRuleOptions<RuleName, EmptyInput, Globals>]
+			: Rule extends readonly [infer Primary, infer Secondary] ? [
+				Primary,
+				NormalizedRuleOptions<RuleName, Secondary, Globals>,
+			]
+				: [Rule, NormalizedRuleOptions<RuleName, EmptyInput, Globals>];
+
+/**
+ * Exact normalized rule map returned from `defineRules`.
+ *
+ * The keys match the user-provided rule map, and values reflect the runtime
+ * tuple normalization plus global separator injection.
+ */
+type DefineRulesResult<Rules extends object, Globals extends PluginGlobals> = {
+	-readonly [RuleName in keyof Rules]: NormalizeRuleSettingWithGlobals<Rules[RuleName], RuleName, Globals>;
+};
+
+/**
+ * Function returned from `createDefineRules`.
+ */
+type DefineRulesFunction<Globals extends PluginGlobals> =
+	/**
+	 * Defines Stylelint rules with type-safe options and applied globals.
+	 *
+	 * @param   rules   A partial rules schema where each key is a rule name and value is its config.
+	 *
+	 * @returns         A normalized rules object ready for Stylelint configuration.
+	 */
+	<const Rules extends object = EmptyInput>(rules?: ExactRulesInput<Rules>) => DefineRulesResult<Rules, Globals>;
+
+/**
+ * Public factory signature for `createDefineRules`.
+ */
+type CreateDefineRules = {
+	/**
+	 * Creates a `defineRules` function without custom global plugin options.
+	 *
+	 * @returns   A function that accepts a `RulesSchema` object and returns a normalized rules config.
+	 */
+	(globals?: undefined): DefineRulesFunction<EmptyInput>;
+
+	/**
+	 * Creates a `defineRules` function bound to a specific set of global plugin options. \
+	 * This factory allows to define rules without repeating global settings each time.
+	 *
+	 * @example
+	 * ```ts
+	 * const defineRules = createDefineRules({
+	 *   separators: {
+	 *     element: '__',
+	 *     modifier: '--',
+	 *     modifierValue: '--',
+	 *   },
+	 * });
+	 *
+	 * export default {
+	 *   rules: defineRules({
+	 *     '@morev/bem/selector-pattern': true,
+	 *   }),
+	 * };
+	 * ```
+	 *
+	 * @param   globals   Global plugin options shared across rules.
+	 *
+	 * @returns           A function that accepts a `RulesSchema` object and returns a normalized rules config.
+	 */
+	<const Globals extends PluginGlobals>(globals: ExactPluginGlobals<Globals>): DefineRulesFunction<Globals>;
+};
+
+export type {
+	CreateDefineRules,
+	DefineRulesFunction,
+	DefineRulesInput,
+	DefineRulesResult,
+	EmptyInput,
+	ExactPluginGlobals,
+	ExactRulesInput,
+	PluginConfig,
+};

--- a/src/create-define-rules/index.ts
+++ b/src/create-define-rules/index.ts
@@ -1,0 +1,1 @@
+export { createDefineRules } from './create-define-rules';

--- a/src/modules/meta/types.ts
+++ b/src/modules/meta/types.ts
@@ -167,8 +167,8 @@ export type RuleMeta = {
 export type RuleSetting<Primary, Secondary> =
 	| null
 	| Primary
-	| [null | Primary]
-	| [null | Primary, Secondary & { [key: string]: any }];
+	| readonly [null | Primary]
+	| readonly [null | Primary, Secondary & { [key: string]: any }];
 // Note about this:            ↑
 // The most accurate type is `Secondary & StylelintSecondaryOptions`,
 // but it feels unnecessarily verbose from the end-user's perspective,
@@ -180,6 +180,10 @@ export type RuleSetting<Primary, Secondary> =
 export type PluginGlobals = {
 	/**
 	 * Defines the separators used to parse BEM class names.
+	 *
+	 * @default { element: '__', modifier: '--', modifierValue: '--' }
 	 */
-	separators?: Separators;
+	separators?: Partial<Separators>;
+	// Note about this: ↑
+	// `Partial` is required to enable autocompletion for some reason.
 };

--- a/src/modules/test-utils/index.ts
+++ b/src/modules/test-utils/index.ts
@@ -2,3 +2,4 @@ export * from './get-rule-by-selector';
 export * from './log';
 export * from './parse-selector';
 export * from './stringify-selector-nodes';
+export * from './typescript-language-service';

--- a/src/modules/test-utils/typescript-language-service.ts
+++ b/src/modules/test-utils/typescript-language-service.ts
@@ -1,0 +1,66 @@
+import ts from 'typescript';
+
+const virtualCompletionFileName = `${process.cwd()}/typescript-language-service.completions.ts`;
+
+const typeScriptCompletionMarker = '/* completion */';
+
+const loadTypeScriptCompilerOptions = () => {
+	const configPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists, 'tsconfig.json');
+
+	if (configPath === undefined) {
+		throw new Error('Cannot find tsconfig.json for TypeScript language service tests.');
+	}
+
+	const config = ts.readConfigFile(configPath, ts.sys.readFile);
+
+	if (config.error !== undefined) {
+		throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
+	}
+
+	return ts.parseJsonConfigFileContent(config.config, ts.sys, process.cwd()).options;
+};
+
+const typeScriptCompilerOptions = loadTypeScriptCompilerOptions();
+
+const getTypeScriptCompletionNames = (source: string) => {
+	const position = source.indexOf(typeScriptCompletionMarker);
+
+	if (position === -1) {
+		throw new Error('Cannot find TypeScript completion marker.');
+	}
+
+	const files = new Map([[virtualCompletionFileName, source]]);
+	const host: ts.LanguageServiceHost = {
+		directoryExists: ts.sys.directoryExists,
+		fileExists: ts.sys.fileExists,
+		getCompilationSettings: () => typeScriptCompilerOptions,
+		getCurrentDirectory: () => process.cwd(),
+		getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+		getDirectories: ts.sys.getDirectories,
+		getScriptFileNames: () => [virtualCompletionFileName],
+		getScriptSnapshot: (fileName) => {
+			const fileContent = files.get(fileName) ?? ts.sys.readFile(fileName);
+
+			return fileContent === undefined ? undefined : ts.ScriptSnapshot.fromString(fileContent);
+		},
+		getScriptVersion: () => '0',
+		readDirectory: ts.sys.readDirectory,
+		readFile: ts.sys.readFile,
+		realpath: ts.sys.realpath,
+	};
+
+	const service = ts.createLanguageService(host, ts.createDocumentRegistry());
+	const completions = service.getCompletionsAtPosition(virtualCompletionFileName, position, {
+		includeCompletionsForModuleExports: false,
+		includeCompletionsWithInsertText: true,
+	});
+
+	service.dispose();
+
+	return completions?.entries.map((entry) => entry.name) ?? [];
+};
+
+export {
+	getTypeScriptCompletionNames,
+	typeScriptCompletionMarker,
+};

--- a/src/modules/test-utils/typescript-language-service.ts
+++ b/src/modules/test-utils/typescript-language-service.ts
@@ -1,11 +1,12 @@
 import ts from 'typescript';
 
-const virtualCompletionFileName = `${process.cwd()}/typescript-language-service.completions.ts`;
+const currentDirectory = process.cwd();
+const virtualCompletionFileName = `${currentDirectory}/typescript-language-service.completions.ts`;
 
 const typeScriptCompletionMarker = '/* completion */';
 
 const loadTypeScriptCompilerOptions = () => {
-	const configPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists, 'tsconfig.json');
+	const configPath = ts.findConfigFile(currentDirectory, ts.sys.fileExists, 'tsconfig.json');
 
 	if (configPath === undefined) {
 		throw new Error('Cannot find tsconfig.json for TypeScript language service tests.');
@@ -17,10 +18,50 @@ const loadTypeScriptCompilerOptions = () => {
 		throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
 	}
 
-	return ts.parseJsonConfigFileContent(config.config, ts.sys, process.cwd()).options;
+	const compilerOptions = ts.convertCompilerOptionsFromJson(
+		config.config.compilerOptions ?? {},
+		currentDirectory,
+		configPath,
+	);
+
+	if (compilerOptions.errors.length > 0) {
+		throw new Error(compilerOptions.errors
+			.map((error) => ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+			.join('\n'));
+	}
+
+	return compilerOptions.options;
 };
 
 const typeScriptCompilerOptions = loadTypeScriptCompilerOptions();
+
+let virtualSource = '';
+let virtualSourceVersion = 0;
+
+const host: ts.LanguageServiceHost = {
+	directoryExists: ts.sys.directoryExists,
+	fileExists: ts.sys.fileExists,
+	getCompilationSettings: () => typeScriptCompilerOptions,
+	getCurrentDirectory: () => currentDirectory,
+	getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+	getDirectories: ts.sys.getDirectories,
+	getScriptFileNames: () => [virtualCompletionFileName],
+	getScriptSnapshot: (fileName) => {
+		const fileContent = fileName === virtualCompletionFileName
+			? virtualSource
+			: ts.sys.readFile(fileName);
+
+		return fileContent === undefined ? undefined : ts.ScriptSnapshot.fromString(fileContent);
+	},
+	getScriptVersion: (fileName) => {
+		return fileName === virtualCompletionFileName ? String(virtualSourceVersion) : '0';
+	},
+	readDirectory: ts.sys.readDirectory,
+	readFile: ts.sys.readFile,
+	realpath: ts.sys.realpath,
+};
+
+const service = ts.createLanguageService(host, ts.createDocumentRegistry());
 
 const getTypeScriptCompletionNames = (source: string) => {
 	const position = source.indexOf(typeScriptCompletionMarker);
@@ -29,33 +70,13 @@ const getTypeScriptCompletionNames = (source: string) => {
 		throw new Error('Cannot find TypeScript completion marker.');
 	}
 
-	const files = new Map([[virtualCompletionFileName, source]]);
-	const host: ts.LanguageServiceHost = {
-		directoryExists: ts.sys.directoryExists,
-		fileExists: ts.sys.fileExists,
-		getCompilationSettings: () => typeScriptCompilerOptions,
-		getCurrentDirectory: () => process.cwd(),
-		getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
-		getDirectories: ts.sys.getDirectories,
-		getScriptFileNames: () => [virtualCompletionFileName],
-		getScriptSnapshot: (fileName) => {
-			const fileContent = files.get(fileName) ?? ts.sys.readFile(fileName);
+	virtualSource = source;
+	virtualSourceVersion++;
 
-			return fileContent === undefined ? undefined : ts.ScriptSnapshot.fromString(fileContent);
-		},
-		getScriptVersion: () => '0',
-		readDirectory: ts.sys.readDirectory,
-		readFile: ts.sys.readFile,
-		realpath: ts.sys.realpath,
-	};
-
-	const service = ts.createLanguageService(host, ts.createDocumentRegistry());
 	const completions = service.getCompletionsAtPosition(virtualCompletionFileName, position, {
 		includeCompletionsForModuleExports: false,
 		includeCompletionsWithInsertText: true,
 	});
-
-	service.dispose();
 
 	return completions?.entries.map((entry) => entry.name) ?? [];
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 		coverage: {
 			enabled: false,
 			provider: 'v8',
+			exclude: ['./src/modules/test-utils/**'],
 		},
 	},
 });


### PR DESCRIPTION
Closes #54.

This PR fixes the public typing of `createDefineRules` so the returned rule map preserves the exact rule keys and normalized value shape from the provided object literal.

## Changes

- Make `createDefineRules` and the returned `defineRules` function generic over the actual user input.
- Preserve exact `keyof typeof rules` instead of widening the result to all `RulesSchema` keys.
- Keep rule secondary options typed, including validation for invalid secondary values.
- Reflect runtime separator injection in the returned type for BEM rules.
- Add TypeScript Language Service tests for autocompletion of globals, nested separators, rule names, and rule secondary options.