### PR TITLE
fix!: Correct the `CONTEXT_DEPENDENT` preset

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -107,7 +107,7 @@ export default {
         '@morev/bem/block-variable': true, // [!code ++]
         '@morev/bem/match-file-name': true, // [!code ++]
         '@morev/bem/no-block-properties': [true, { // [!code ++]
-          presets: ['EXTERNAL_GEOMETRY', 'CONTEXT'], // [!code ++]
+          presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'], // [!code ++]
         }], // [!code ++]
         '@morev/bem/no-chained-entities': true, // [!code ++]
         '@morev/bem/no-side-effects': true, // [!code ++]
@@ -198,7 +198,7 @@ export default {
         '@morev/bem/block-variable': [true, {}],
         '@morev/bem/match-file-name': [true, {}],
         '@morev/bem/no-block-properties': [true, {
-          presets: ['EXTERNAL_GEOMETRY', 'CONTEXT'],
+          presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'],
           ignoreBlocks: ['*swiper*'],
         }],
         '@morev/bem/no-chained-entities': [true, {}],

--- a/src/rules/bem/no-block-properties/__tests__/no-block-properties.implementation.test.ts
+++ b/src/rules/bem/no-block-properties/__tests__/no-block-properties.implementation.test.ts
@@ -288,6 +288,34 @@ testRule({
 });
 
 testRule({
+	description: '`CONTEXT_DEPENDENT` preset',
+	config: [true, { presets: ['CONTEXT_DEPENDENT'] }],
+	accept: [
+		{
+			description: 'Block uses the grid container shorthand',
+			code: `
+				.the-component { grid: none; }
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Block has a context-dependent property',
+			code: `
+				.the-component { vertical-align: middle; }
+			`,
+			warnings: [
+				{
+					message: messages.unexpected('vertical-align', '.the-component', 'block', 'CONTEXT_DEPENDENT'),
+					line: 1, column: 18,
+					endLine: 1, endColumn: 32,
+				},
+			],
+		},
+	],
+});
+
+testRule({
 	description: '`ignoreBlocks` option',
 	config: [true, { ignoreBlocks: ['swiper-*', /.*legacy.*/] }],
 	accept: [

--- a/src/rules/bem/no-block-properties/no-block-properties.docs.md
+++ b/src/rules/bem/no-block-properties/no-block-properties.docs.md
@@ -107,7 +107,7 @@ export default {
 export type NoBlockPropertiesOptions = {
   /**
    * List of presets to apply globally. \
-   * Available built-in presets: `['EXTERNAL_GEOMETRY', 'CONTEXT', 'POSITIONING']`.
+   * Available built-in presets: `['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT', 'POSITIONING']`.
    *
    * @default ['EXTERNAL_GEOMETRY']
    */
@@ -282,11 +282,11 @@ using [`customPresets`](#custompresets) option if needed.
 
 #### Built-in presets
 
-| Preset name         | Description                                                                 |
-| ------------------- | --------------------------------------------------------------------------- |
-| `EXTERNAL_GEOMETRY` | Properties that control external geometry *(enabled by default)*.           |
-| `CONTEXT`           | Properties that influence layout behavior within a parent container.        |
-| `POSITIONING`       | Properties related to absolute or relative positioning of the block itself. |
+| Preset name         | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `EXTERNAL_GEOMETRY` | Properties that control external geometry *(enabled by default)*.                      |
+| `CONTEXT_DEPENDENT` | Properties whose behavior depends on an external layout, counter, or stacking context. |
+| `POSITIONING`       | Properties related to absolute or relative positioning of the block itself.            |
 
 :::: details Show properties list
 
@@ -300,16 +300,17 @@ const BUILTIN_PRESETS = {
     'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
   ]),
 
-  // Properties that influence layout behavior within a parent container
-  CONTEXT: new Set([
+  // Properties whose behavior depends on an external layout, counter, or stacking context
+  CONTEXT_DEPENDENT: new Set([
     'float', 'clear',
+    'vertical-align',
     'flex', 'flex-grow', 'flex-shrink', 'flex-basis',
-    'grid', 'grid-area',
+    'grid-area',
     'grid-row', 'grid-row-start', 'grid-row-end',
     'grid-column', 'grid-column-start', 'grid-column-end',
-    'place-self', 'align-self',
+    'place-self', 'align-self', 'justify-self',
     'order',
-    'counter-increment',
+    'counter-increment', 'counter-set',
     'z-index',
   ]),
 
@@ -340,7 +341,7 @@ This preset covers properties that directly affect external layout,
 and is considered the most universally recommended restriction for BEM blocks.
 
 ::: warning
-It is strongly encouraged to extend the rule configuration with additional presets like `CONTEXT` and `POSITIONING`,
+It is strongly encouraged to extend the rule configuration with additional presets like `CONTEXT_DEPENDENT` and `POSITIONING`,
 or by manually specifying properties using [disallowProperties](#disallowproperties) option
 to ensure more consistent and predictable BEM block isolation.
 :::
@@ -498,7 +499,7 @@ This gives you fine-grained control over exceptions to global restrictions.
 ```js
 {
   '@morev/bem/no-block-properties': [true, {
-    presets: ['EXTERNAL_GEOMETRY', 'CONTEXT'],
+    presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'],
     allowProperties: ['z-index'],
   }],
 }
@@ -507,7 +508,7 @@ This gives you fine-grained control over exceptions to global restrictions.
 In this example:
 
 - The rule restricts external geometry and context-related properties.
-- `z-index` is explicitly allowed, even though it's part of the `'CONTEXT'` preset.
+- `z-index` is explicitly allowed, even though it's part of the `'CONTEXT_DEPENDENT'` preset.
 
 ---
 
@@ -726,7 +727,7 @@ export default {
         unexpected: (property, selector, context, preset) => {
           const propertyType = (() => {
             if (preset === 'EXTERNAL_GEOMETRY') return 'свойство внешней геометрии';
-            if (preset === 'CONTEXT') return 'контекстуально-зависимое свойство';
+            if (preset === 'CONTEXT_DEPENDENT') return 'контекстуально-зависимое свойство';
             if (preset === 'POSITIONING') return 'свойство позиционирования';
             return 'свойство';
           })();

--- a/src/rules/bem/no-block-properties/no-block-properties.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.ts
@@ -25,7 +25,7 @@ export default createRule({
 			const propertyType = (() => {
 				if (presetName === 'EXTERNAL_GEOMETRY') return 'external geometry';
 				if (presetName === 'POSITIONING') return 'positioning';
-				if (presetName === 'CONTEXT') return 'contextual';
+				if (presetName === 'CONTEXT_DEPENDENT') return 'context-dependent';
 				return '';
 			})();
 

--- a/src/rules/bem/no-block-properties/no-block-properties.types.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.types.ts
@@ -11,7 +11,7 @@ export type PrimaryOption = true;
 export type SecondaryOption = {
 	/**
 	 * List of presets to apply globally. \
-	 * Available built-in presets: `['EXTERNAL_GEOMETRY', 'CONTEXT', 'POSITIONING']`.
+	 * Available built-in presets: `['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT', 'POSITIONING']`.
 	 *
 	 * @default ['EXTERNAL_GEOMETRY']
 	 */

--- a/src/rules/bem/no-block-properties/utils/create-properties-registry/create-properties-registry.test.ts
+++ b/src/rules/bem/no-block-properties/utils/create-properties-registry/create-properties-registry.test.ts
@@ -3,17 +3,25 @@ import { createPropertiesRegistry } from './create-properties-registry';
 describe(createPropertiesRegistry, () => {
 	it('Merges built-in presets and property-to-preset map correctly', () => {
 		const registry = createPropertiesRegistry({
-			presets: ['EXTERNAL_GEOMETRY', 'CONTEXT'],
+			presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'],
 		});
 
 		expect(registry.propertyToPresetMap.get('margin')).toBe('EXTERNAL_GEOMETRY');
-		expect(registry.propertyToPresetMap.get('z-index')).toBe('CONTEXT');
+		expect(registry.propertyToPresetMap.get('counter-set')).toBe('CONTEXT_DEPENDENT');
+		expect(registry.propertyToPresetMap.get('justify-self')).toBe('CONTEXT_DEPENDENT');
+		expect(registry.propertyToPresetMap.get('vertical-align')).toBe('CONTEXT_DEPENDENT');
+		expect(registry.propertyToPresetMap.get('z-index')).toBe('CONTEXT_DEPENDENT');
+		expect(registry.propertyToPresetMap.has('grid')).toBe(false);
 
 		expect(registry.disallowedProperties.block.has('margin')).toBe(true);
 		expect(registry.disallowedProperties.modifier.has('margin')).toBe(true);
 
 		expect(registry.disallowedProperties.block.has('z-index')).toBe(true);
 		expect(registry.disallowedProperties.modifier.has('z-index')).toBe(true);
+		expect(registry.disallowedProperties.block.has('counter-set')).toBe(true);
+		expect(registry.disallowedProperties.block.has('justify-self')).toBe(true);
+		expect(registry.disallowedProperties.block.has('vertical-align')).toBe(true);
+		expect(registry.disallowedProperties.block.has('grid')).toBe(false);
 	});
 
 	it('Merges custom presets into property-to-preset map', () => {

--- a/src/rules/bem/no-block-properties/utils/create-properties-registry/create-properties-registry.ts
+++ b/src/rules/bem/no-block-properties/utils/create-properties-registry/create-properties-registry.ts
@@ -12,15 +12,16 @@ const BUILTIN_PRESETS = {
 		'margin-inline', 'margin-inline-start', 'margin-inline-end',
 		'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
 	]),
-	CONTEXT: new Set([
+	CONTEXT_DEPENDENT: new Set([
 		'float', 'clear',
+		'vertical-align',
 		'flex', 'flex-grow', 'flex-shrink', 'flex-basis',
-		'grid', 'grid-area',
+		'grid-area',
 		'grid-row', 'grid-row-start', 'grid-row-end',
 		'grid-column', 'grid-column-start', 'grid-column-end',
-		'place-self', 'align-self',
+		'place-self', 'align-self', 'justify-self',
 		'order',
-		'counter-increment',
+		'counter-increment', 'counter-set',
 		'z-index',
 	]),
 	POSITIONING: new Set([


### PR DESCRIPTION
#### Description

Rename `CONTEXT` and align its documented property membership.

BREAKING CHANGE: The built-in `CONTEXT` preset is now named `CONTEXT_DEPENDENT`. It now includes `counter-set`, `justify-self`, and `vertical-align`, and no longer includes `grid`.

#### Linked issue

-