### PR TITLE
feat(bem): Add `no-misplaced-side-effects` rule

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,7 @@ pnpm install
 ### Common scripts
 
 - **`pnpm prepare`** \
-  Runs `generate-meta` and installs Git hooks via [lefthook]. \
+  Builds the package and installs Git hooks via [lefthook]. \
   Runs automatically after `pnpm install`.
 
 - **`pnpm test`** \

--- a/.github/CONTRIBUTING_RU.md
+++ b/.github/CONTRIBUTING_RU.md
@@ -51,7 +51,7 @@ pnpm install
 ### Основные скрипты
 
 - **`pnpm prepare`** \
-  Запускает `generate-meta` и устанавливает Git-хуки через [lefthook]. \
+  Собирает пакет и устанавливает Git-хуки через [lefthook]. \
   Выполняется автоматически после `pnpm install`.
 
 - **`pnpm test`** \

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Artifacts
 dist
+docs/.vitepress/.temp
 docs/.vitepress/cache
 
 # Editors

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -110,6 +110,7 @@ export default {
           presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'], // [!code ++]
         }], // [!code ++]
         '@morev/bem/no-chained-entities': true, // [!code ++]
+        '@morev/bem/no-misplaced-side-effects': true, // [!code ++]
         '@morev/bem/no-side-effects': true, // [!code ++]
         '@morev/bem/selector-pattern': true, // [!code ++]
       }, // [!code ++]
@@ -202,6 +203,7 @@ export default {
           ignoreBlocks: ['*swiper*'],
         }],
         '@morev/bem/no-chained-entities': [true, {}],
+        '@morev/bem/no-misplaced-side-effects': [true, {}],
         '@morev/bem/no-side-effects': [true, {
           ignore: [
             '*swiper*',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"scripts": {
-		"prepare": "pnpm generate-meta && lefthook install",
+		"prepare": "pnpm build && lefthook install",
 		"test": "vitest",
 		"typecheck": "tsc --noEmit",
 		"spellcheck": "cspell --no-progress --show-suggestions --unique",

--- a/src/create-define-rules/create-define-rules.ts
+++ b/src/create-define-rules/create-define-rules.ts
@@ -15,6 +15,7 @@ const rulesWithSeparators = [
 	'@morev/bem/match-file-name',
 	'@morev/bem/no-block-properties',
 	'@morev/bem/no-chained-entities',
+	'@morev/bem/no-misplaced-side-effects',
 	'@morev/bem/no-side-effects',
 	'@morev/bem/selector-pattern',
 ] as const satisfies ReadonlyArray<keyof RulesSchema>;

--- a/src/modules/bem/index.ts
+++ b/src/modules/bem/index.ts
@@ -1,6 +1,7 @@
 export * from './constants';
 export * from './utils/get-bem-block/get-bem-block';
 export * from './utils/get-most-specific-entity-part/get-most-specific-entity-part';
+export * from './utils/is-direct-bem-entity/is-direct-bem-entity';
 export * from './utils/resolve-bem-chain/resolve-bem-chain';
 export * from './utils/resolve-bem-entities/resolve-bem-entities';
 export type * from './types';

--- a/src/modules/bem/utils/is-direct-bem-entity/is-direct-bem-entity.test.ts
+++ b/src/modules/bem/utils/is-direct-bem-entity/is-direct-bem-entity.test.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_SEPARATORS, resolveBemEntities } from '#modules/bem';
+import { isDirectBemEntity } from './is-direct-bem-entity';
+
+describe(isDirectBemEntity, () => {
+	it('Recognizes entities in the direct compound context', () => {
+		const entities = resolveBemEntities({
+			source: '.foo:is(.bar:not(.baz)).foo--mod.component',
+			separators: DEFAULT_SEPARATORS,
+		});
+
+		const result = entities.map((entity) => ({
+			block: entity.block.value,
+			context: entity.sourceContext,
+			isDirect: isDirectBemEntity(entity),
+		}));
+
+		expect(result).toStrictEqual([
+			{ block: 'foo', context: null, isDirect: true },
+			{ block: 'component', context: 'entity', isDirect: true },
+			{ block: 'bar', context: ':is', isDirect: false },
+			{ block: 'foo', context: 'modifier', isDirect: true },
+			{ block: 'baz', context: ':not', isDirect: false },
+		]);
+	});
+});

--- a/src/modules/bem/utils/is-direct-bem-entity/is-direct-bem-entity.ts
+++ b/src/modules/bem/utils/is-direct-bem-entity/is-direct-bem-entity.ts
@@ -1,0 +1,15 @@
+import type { BemEntity } from '#modules/bem';
+
+/**
+ * Checks whether a BEM entity belongs directly to its compound selector
+ * rather than to a nested functional pseudo-class.
+ *
+ * @param   entity   BEM entity to inspect.
+ *
+ * @returns          Whether the entity belongs to the direct compound context.
+ */
+export const isDirectBemEntity = (entity: BemEntity) => {
+	return entity.sourceContext === null
+		|| entity.sourceContext === 'entity'
+		|| entity.sourceContext === 'modifier';
+};

--- a/src/modules/meta/__generated__/rules-meta.ts
+++ b/src/modules/meta/__generated__/rules-meta.ts
@@ -33,6 +33,16 @@ export const rulesMeta = [
 		vitepressLink: '/rules/bem/no-side-effects.html',
 	},
 	{
+		id: '@morev/bem/no-misplaced-side-effects',
+		scope: 'bem',
+		name: 'no-misplaced-side-effects',
+		description: 'Requires BEM side-effects to be declared within the entity they affect.',
+		fixable: false,
+		docsPath: 'src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.docs.md',
+		vitepressPath: '/rules/bem/no-misplaced-side-effects.md',
+		vitepressLink: '/rules/bem/no-misplaced-side-effects.html',
+	},
+	{
 		id: '@morev/bem/no-chained-entities',
 		scope: 'bem',
 		name: 'no-chained-entities',
@@ -146,6 +156,16 @@ export const scopedRulesMeta = [
 				docsPath: 'src/rules/bem/no-chained-entities/no-chained-entities.docs.md',
 				vitepressPath: '/rules/bem/no-chained-entities.md',
 				vitepressLink: '/rules/bem/no-chained-entities.html',
+			},
+			{
+				id: '@morev/bem/no-misplaced-side-effects',
+				scope: 'bem',
+				name: 'no-misplaced-side-effects',
+				description: 'Requires BEM side-effects to be declared within the entity they affect.',
+				fixable: false,
+				docsPath: 'src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.docs.md',
+				vitepressPath: '/rules/bem/no-misplaced-side-effects.md',
+				vitepressLink: '/rules/bem/no-misplaced-side-effects.html',
 			},
 			{
 				id: '@morev/bem/no-side-effects',

--- a/src/modules/meta/__generated__/rules-schema.ts
+++ b/src/modules/meta/__generated__/rules-schema.ts
@@ -7,6 +7,7 @@ import type * as blockVariable from '#rules/bem/block-variable/block-variable.ty
 import type * as matchFileName from '#rules/bem/match-file-name/match-file-name.types';
 import type * as noBlockProperties from '#rules/bem/no-block-properties/no-block-properties.types';
 import type * as noChainedEntities from '#rules/bem/no-chained-entities/no-chained-entities.types';
+import type * as noMisplacedSideEffects from '#rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.types';
 import type * as noSideEffects from '#rules/bem/no-side-effects/no-side-effects.types';
 import type * as selectorPattern from '#rules/bem/selector-pattern/selector-pattern.types';
 import type * as noUnusedVariables from '#rules/sass/no-unused-variables/no-unused-variables.types';
@@ -33,6 +34,13 @@ export type RulesSchema = {
 	 * @see https://morevm.github.io/stylelint-plugin/rules/bem/no-side-effects.html
 	 */
 	'@morev/bem/no-side-effects': RuleSetting<noSideEffects.PrimaryOption, noSideEffects.SecondaryOption>;
+
+	/**
+	 * Requires BEM side-effects to be declared within the entity they affect.
+	 *
+	 * @see https://morevm.github.io/stylelint-plugin/rules/bem/no-misplaced-side-effects.html
+	 */
+	'@morev/bem/no-misplaced-side-effects': RuleSetting<noMisplacedSideEffects.PrimaryOption, noMisplacedSideEffects.SecondaryOption>;
 
 	/**
 	 * Disallows splitting BEM entities across multiple chained `&` selectors in SCSS.

--- a/src/modules/selectors/index.ts
+++ b/src/modules/selectors/index.ts
@@ -1,5 +1,6 @@
 export * from './parse-selectors/parse-selectors';
 export * from './resolve-nested-selector/resolve-nested-selector';
 export * from './resolve-selector-nodes/resolve-selector-nodes';
+export * from './resolve-selector-nodes/utils/get-resolved-nodes-source-range';
 export * from './selector-nodes-to-string/selector-nodes-to-string';
 export type * from './types';

--- a/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.test.ts
+++ b/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.test.ts
@@ -10,7 +10,7 @@ const resolveSelectorInContext = (
 	return resolveNestedSelector({
 		source: customSelector,
 		node: getRuleBySelector(code, selector),
-	}).map((result) => omit(result, 'replacements'));
+	}).map((result) => omit(result, 'lexicalParent', 'replacements'));
 };
 
 const resolveSelectorWithReplacements = (
@@ -21,6 +21,57 @@ const resolveSelectorWithReplacements = (
 };
 
 describe(resolveNestedSelector, () => {
+	describe('Lexical parent', () => {
+		it('Returns `null` for a flat top-level selector', () => {
+			const code = `.block__source:hover .block__target {}`;
+			const [selector] = resolveNestedSelector({
+				node: getRuleBySelector(code, '.block__source:hover .block__target'),
+			});
+
+			expect(selector).toMatchObject({
+				lexicalParent: null,
+				parent: null,
+			});
+		});
+
+		it('Preserves the owner through an explicit `@at-root` selector', () => {
+			const code = `
+				.block__link {
+					@at-root .block__source:hover .block__target {}
+				}
+			`;
+			const selectors = resolveNestedSelector({
+				node: getRuleBySelector(code, '.block__source:hover .block__target'),
+			});
+
+			expect(selectors).toHaveLength(1);
+			expect(selectors[0]).toMatchObject({
+				lexicalParent: '.block__link',
+				parent: null,
+				resolved: '.block__source:hover .block__target',
+			});
+		});
+
+		it('Looks through a bare `@at-root` wrapper for the lexical owner', () => {
+			const code = `
+				.block__link {
+					@at-root {
+						.block__target {}
+					}
+				}
+			`;
+			const [selector] = resolveNestedSelector({
+				node: getRuleBySelector(code, '.block__target'),
+			});
+
+			expect(selector).toMatchObject({
+				lexicalParent: '.block__link',
+				parent: null,
+				resolved: '.block__target',
+			});
+		});
+	});
+
 	// Tests from https://github.com/csstools/postcss-resolve-nested-selector/blob/main/test/api.test.mjs
 	describe('CSS features', () => {
 		it('Resolves top-level declarations', () => {

--- a/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.ts
+++ b/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.ts
@@ -330,6 +330,13 @@ const resolveSelectorTrees = (trees: ResolvedPathItem[][]): ResolvedSelector[] =
 		// Every path segment has already been resolved sequentially.
 		// The preceding segment therefore contains the exact parent context.
 		const context = tree.at(-2)?.resolvedContext ?? '';
+		// Bare `@at-root` segments have no selector of their own and may clear the
+		// emitted context. Look through them to retain the nearest selector that
+		// lexically contains the declaration.
+		const lexicalParent = tree
+			.slice(0, -1)
+			.findLast(({ value }) => !!value)
+			?.resolvedContext ?? null;
 		// Variable interpolation has already changed `resolvedValue`, but its ranges are still
 		// expressed in source coordinates. Resolve all ranges together after nesting is handled.
 		const pendingReplacements: PendingSelectorReplacement[] =
@@ -440,6 +447,7 @@ const resolveSelectorTrees = (trees: ResolvedPathItem[][]): ResolvedSelector[] =
 		return {
 			source,
 			resolved,
+			lexicalParent,
 			parent,
 			substitutions,
 			replacements,

--- a/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.types.ts
+++ b/src/modules/selectors/resolve-nested-selector/resolve-nested-selector.types.ts
@@ -170,8 +170,17 @@ export type ResolvedSelector = {
 	replacements: ResolvedSelectorReplacement[];
 
 	/**
-	 * The resolved parent selector for this context.
-	 * `null` in case of a top-level selector.
+	 * The nearest resolved selector context that lexically contains this selector. \
+	 * Unlike `parent`, it is preserved when `@at-root` removes that context
+	 * from the emitted selector.
+	 *
+	 * @example '.block__element'
+	 */
+	lexicalParent: string | null;
+
+	/**
+	 * The resolved parent context substituted or injected into this selector.
+	 * `null` when the emitted selector does not use a parent context.
 	 *
 	 * @example '.block'
 	 */

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.test.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.test.ts
@@ -71,6 +71,19 @@ describe(resolveSelectorNodes, () => {
 			);
 		});
 
+		it('Exposes the parsed parent and selector replacements', () => {
+			const node = getRuleBySelector(`
+				.layout .block__element {
+					.block:hover & + & {}
+				}
+			`, `.block:hover & + &`);
+
+			const [{ parent, replacements }] = resolveSelectorNodes({ node });
+
+			expect(stringifySelectorNodes(parent ?? [])).toStrictEqual(['.layout', ' ', '.block__element']);
+			expect(replacements.map(({ type }) => type)).toStrictEqual(['nesting', 'nesting']);
+		});
+
 		it('All resolved nodes have `meta.sourceMatches` property', () => {
 			const node = getRuleBySelector(`
 				.foo .block {

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.test.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.test.ts
@@ -84,6 +84,22 @@ describe(resolveSelectorNodes, () => {
 			expect(replacements.map(({ type }) => type)).toStrictEqual(['nesting', 'nesting']);
 		});
 
+		it('Exposes the lexical parent removed from the emitted selector by `@at-root`', () => {
+			const node = getRuleBySelector(`
+				.common-star-control__star {
+					&::before {
+						@at-root .common-star-control__star:hover ~ .common-star-control__star::before {}
+					}
+				}
+			`, `.common-star-control__star:hover ~ .common-star-control__star::before`);
+
+			const [{ lexicalParent, parent }] = resolveSelectorNodes({ node });
+
+			expect(stringifySelectorNodes(lexicalParent ?? []))
+				.toStrictEqual(['.common-star-control__star', '::before']);
+			expect(parent).toBeNull();
+		});
+
 		it('All resolved nodes have `meta.sourceMatches` property', () => {
 			const node = getRuleBySelector(`
 				.foo .block {

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.ts
@@ -21,6 +21,9 @@ export const resolveSelectorNodes = (options: Options): MappedSelector[] => {
 		// so it's safe to take the first one directly.
 		const sourceSelectorNodes = parseSelectors(selector.source)[0];
 		const resolvedSelectorNodes = parseSelectors(selector.resolved)[0];
+		const lexicalParentSelectorNodes = selector.lexicalParent
+			? parseSelectors(selector.lexicalParent)[0]
+			: null;
 		const parentSelectorNodes = selector.parent
 			? parseSelectors(selector.parent)[0]
 			: null;
@@ -37,6 +40,7 @@ export const resolveSelectorNodes = (options: Options): MappedSelector[] => {
 			.map((node) => linkSourceMeta(node, sourceNodeMeta, offset));
 
 		return {
+			lexicalParent: lexicalParentSelectorNodes,
 			parent: parentSelectorNodes,
 			resolved: resolvedNodes,
 			replacements: selector.replacements,

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.ts
@@ -21,6 +21,9 @@ export const resolveSelectorNodes = (options: Options): MappedSelector[] => {
 		// so it's safe to take the first one directly.
 		const sourceSelectorNodes = parseSelectors(selector.source)[0];
 		const resolvedSelectorNodes = parseSelectors(selector.resolved)[0];
+		const parentSelectorNodes = selector.parent
+			? parseSelectors(selector.parent)[0]
+			: null;
 
 		// Filter out incomplete/invalid input.
 		if (isEmpty(sourceSelectorNodes) || isEmpty(resolvedSelectorNodes)) {
@@ -34,7 +37,9 @@ export const resolveSelectorNodes = (options: Options): MappedSelector[] => {
 			.map((node) => linkSourceMeta(node, sourceNodeMeta, offset));
 
 		return {
+			parent: parentSelectorNodes,
 			resolved: resolvedNodes,
+			replacements: selector.replacements,
 			source: sourceSelectorNodes,
 		};
 	});

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.types.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.types.ts
@@ -1,5 +1,6 @@
 import type postcss from 'postcss';
 import type parser from 'postcss-selector-parser';
+import type { ResolvedSelectorReplacement } from '#modules/selectors/resolve-nested-selector/resolve-nested-selector.types';
 
 /**
  * Options for resolving a nested selector.
@@ -67,9 +68,20 @@ export type ResolvedNode<Base = parser.Node> = Base & {
  */
 export type MappedSelector = {
 	/**
+	 * Parsed resolved parent selector for the current branch. \
+	 * `null` for a top-level selector.
+	 */
+	parent: parser.Node[] | null;
+
+	/**
 	 * Resolved selector nodes with links to corresponding source nodes.
 	 */
 	resolved: ResolvedNode[];
+
+	/**
+	 * Ordered replacements applied while resolving the selector.
+	 */
+	replacements: ResolvedSelectorReplacement[];
 
 	/**
 	 * Original source selector nodes.

--- a/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.types.ts
+++ b/src/modules/selectors/resolve-selector-nodes/resolve-selector-nodes.types.ts
@@ -68,8 +68,14 @@ export type ResolvedNode<Base = parser.Node> = Base & {
  */
 export type MappedSelector = {
 	/**
-	 * Parsed resolved parent selector for the current branch. \
-	 * `null` for a top-level selector.
+	 * Parsed nearest selector context that lexically contains the current branch. \
+	 * Preserved when `@at-root` removes that context from the emitted selector.
+	 */
+	lexicalParent: parser.Node[] | null;
+
+	/**
+	 * Parsed resolved parent context used to produce the current branch. \
+	 * `null` when no parent context was substituted or injected.
 	 */
 	parent: parser.Node[] | null;
 

--- a/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.test.ts
+++ b/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.test.ts
@@ -1,0 +1,22 @@
+import { getRuleBySelector } from '#modules/test-utils';
+import { resolveSelectorNodes } from '../resolve-selector-nodes';
+import { getResolvedNodesSourceRange } from './get-resolved-nodes-source-range';
+
+describe(getResolvedNodesSourceRange, () => {
+	it('Returns `null` for an empty fragment', () => {
+		expect(getResolvedNodesSourceRange([])).toBeNull();
+	});
+
+	it('Uses the source matches of a non-first selector-list branch', () => {
+		const node = getRuleBySelector(
+			'.block { &:hover, & .block__element {} }',
+			'&:hover, & .block__element',
+		);
+		const [, { resolved }] = resolveSelectorNodes({ node });
+
+		expect(getResolvedNodesSourceRange(resolved)).toStrictEqual({
+			index: 9,
+			endIndex: 26,
+		});
+	});
+});

--- a/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.test.ts
+++ b/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.test.ts
@@ -19,4 +19,30 @@ describe(getResolvedNodesSourceRange, () => {
 			endIndex: 26,
 		});
 	});
+
+	it('Spans multiple source matches collapsed into one resolved node', () => {
+		const node = getRuleBySelector(
+			'.block { &__item { &:hover &--active {} } }',
+			'&:hover &--active',
+		);
+		const [{ resolved }] = resolveSelectorNodes({ node });
+
+		expect(getResolvedNodesSourceRange(resolved.slice(-1))).toStrictEqual({
+			index: 8,
+			endIndex: 17,
+		});
+	});
+
+	it('Spans a parent interpolation and its suffix collapsed into one resolved node', () => {
+		const node = getRuleBySelector(
+			'.block { &__item { &:hover #{&}--active {} } }',
+			'&:hover #{&}--active',
+		);
+		const [{ resolved }] = resolveSelectorNodes({ node });
+
+		expect(getResolvedNodesSourceRange(resolved.slice(-1))).toStrictEqual({
+			index: 8,
+			endIndex: 20,
+		});
+	});
 });

--- a/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.ts
+++ b/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.ts
@@ -14,8 +14,8 @@ export const getResolvedNodesSourceRange = (nodes: ResolvedNode[]) => {
 		.filter((node) => !isEmpty(node.meta.sourceMatches));
 	if (isEmpty(sourceMappedNodes)) return null;
 
-	const firstMatch = sourceMappedNodes[0].meta.sourceMatches.at(-1)!;
-	const lastMatch = sourceMappedNodes.at(-1)!.meta.sourceMatches[0];
+	const firstMatch = sourceMappedNodes[0].meta.sourceMatches[0];
+	const lastMatch = sourceMappedNodes.at(-1)!.meta.sourceMatches.at(-1)!;
 
 	return {
 		index: firstMatch.sourceRange[0] + firstMatch.offset,

--- a/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.ts
+++ b/src/modules/selectors/resolve-selector-nodes/utils/get-resolved-nodes-source-range.ts
@@ -1,0 +1,24 @@
+import { isEmpty } from '@morev/utils';
+import type { ResolvedNode } from '../resolve-selector-nodes.types';
+
+/**
+ * Resolves the report range of a contiguous resolved selector fragment
+ * from its original source matches.
+ *
+ * @param   nodes   Resolved selector nodes that form the fragment.
+ *
+ * @returns         Absolute source indices, or `null` when the fragment has no source matches.
+ */
+export const getResolvedNodesSourceRange = (nodes: ResolvedNode[]) => {
+	const sourceMappedNodes = nodes
+		.filter((node) => !isEmpty(node.meta.sourceMatches));
+	if (isEmpty(sourceMappedNodes)) return null;
+
+	const firstMatch = sourceMappedNodes[0].meta.sourceMatches.at(-1)!;
+	const lastMatch = sourceMappedNodes.at(-1)!.meta.sourceMatches[0];
+
+	return {
+		index: firstMatch.sourceRange[0] + firstMatch.offset,
+		endIndex: lastMatch.sourceRange[1] + lastMatch.offset,
+	};
+};

--- a/src/modules/selectors/resolve-selector-nodes/utils/index.ts
+++ b/src/modules/selectors/resolve-selector-nodes/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './extract-node-source-meta';
 export * from './get-normalized-node-string';
+export * from './get-resolved-nodes-source-range';
 export * from './link-source-meta';

--- a/src/rules/bem/no-block-properties/no-block-properties.ts
+++ b/src/rules/bem/no-block-properties/no-block-properties.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from '@morev/utils';
 import * as v from 'valibot';
-import { resolveBemEntities } from '#modules/bem';
+import { isDirectBemEntity, resolveBemEntities } from '#modules/bem';
 import { getRuleDeclarations, isPseudoElementNode } from '#modules/postcss';
 import { createRule, extractSeparators, mergeMessages, vMessagesSchema, vSeparatorsSchema, vStringOrRegExpSchema } from '#modules/rule-utils';
 import { parseSelectors, resolveNestedSelector } from '#modules/selectors';
@@ -100,7 +100,7 @@ export default createRule({
 					source: resolvedSelector.resolved,
 				}).filter((bemEntity) => {
 					return bemEntity.bemSelector.startsWith(resolvedSelector.parent ?? '')
-						&& [null, 'modifier', 'entity'].includes(bemEntity.sourceContext);
+						&& isDirectBemEntity(bemEntity);
 				});
 
 				const entitiesToReport = selectorBemEntities

--- a/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.configuration.test.ts
+++ b/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.configuration.test.ts
@@ -1,0 +1,56 @@
+import rule from '../no-misplaced-side-effects';
+
+const { ruleName } = rule;
+const testRuleConfig = createTestRuleConfig({ ruleName });
+
+testRuleConfig({
+	description: 'Primary option',
+	accept: [
+		{ description: 'Enabled rule', config: true },
+		{ description: 'Skipped rule', config: null },
+	],
+	reject: [
+		{ config: false },
+		{ config: 'always' },
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary options object',
+	accept: [
+		{ description: 'No value', config: [true] },
+		{ description: 'Empty object', config: [true, {}] },
+	],
+	reject: [
+		{ description: 'Secondary is not an object', config: [true, 'always'] },
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary option > messages',
+	accept: [
+		{
+			config: [true, {
+				messages: {
+					misplaced: () => '',
+				},
+			}],
+		},
+	],
+	reject: [
+		{
+			config: [true, {
+				messages: {
+					misplaced: 1,
+				},
+			}],
+		},
+		{
+			config: [true, {
+				messages: {
+					unknown: () => '',
+				},
+			}],
+		},
+	],
+});

--- a/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
+++ b/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
@@ -97,6 +97,25 @@ testRule({
 			`,
 		},
 		{
+			description: 'Ignores keyframe selectors',
+			code: `
+				.block {
+					@keyframes pulse {
+						from { opacity: 0; }
+						to { opacity: 1; }
+					}
+				}
+			`,
+		},
+		{
+			description: 'Ignores side-effects declared within an ambiguous owner',
+			code: `
+				:is(.block__label, .block__icon) {
+					.block__link:hover .block__target {}
+				}
+			`,
+		},
+		{
 			description: 'Ignores non-BEM and ambiguous targets',
 			code: `
 				.block__link {
@@ -263,6 +282,21 @@ testRule({
 				},
 			],
 		},
+		{
+			description: 'Reports converging resolution paths once',
+			code: `
+				.block__link.foo, .block__link.bar {
+					&:hover .block__label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 23,
+				},
+			],
+		},
 	],
 });
 
@@ -345,6 +379,17 @@ testCssRule({
 				@media (width >= 320px) {
 					.block__label {
 						.block__link:hover & {}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Does not repeat inherited side-effects inside functional pseudos',
+			codeFilename: 'block.css',
+			code: `
+				.block__label {
+					.block__link:hover & {
+						:is(.is-active, &:focus)& {}
 					}
 				}
 			`,

--- a/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
+++ b/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
@@ -75,6 +75,18 @@ testRule({
 			`,
 		},
 		{
+			description: 'Preserves lexical ownership when `@at-root` removes the emitted parent',
+			code: `
+				.common-star-control__star {
+					$self: &;
+
+					&::before {
+						@at-root #{$self}:hover ~ #{$self}::before {}
+					}
+				}
+			`,
+		},
+		{
 			description: 'Does not repeat an inherited side-effect for nested states',
 			code: `
 				.block__label {
@@ -202,14 +214,14 @@ testRule({
 			description: 'Reports misplaced ownership through `@at-root`',
 			code: `
 				.block__link {
-					@at-root &:hover .block__label {}
+					@at-root .block__link:hover .block__label {}
 				}
 			`,
 			warnings: [
 				{
 					message: messages.misplaced('.block__label', '.block__link'),
-					line: 2, column: 19,
-					endLine: 2, endColumn: 32,
+					line: 2, column: 30,
+					endLine: 2, endColumn: 43,
 				},
 			],
 		},

--- a/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
+++ b/src/rules/bem/no-misplaced-side-effects/__tests__/no-misplaced-side-effects.implementation.test.ts
@@ -1,0 +1,359 @@
+import rule from '../no-misplaced-side-effects';
+
+const { ruleName, messages } = rule;
+const testRule = createTestRule({ ruleName, customSyntax: 'postcss-scss' });
+const testCssRule = createTestRule({ ruleName });
+
+testRule({
+	description: 'Default options',
+	config: [true],
+	accept: [
+		{
+			description: 'Accepts side-effects declared within the target element',
+			code: `
+				.block {
+					$b: #{&};
+
+					&__label {
+						#{$b}__link:hover & {}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Treats a modifier as a separate owner',
+			code: `
+				.block {
+					$b: #{&};
+
+					&__item {
+						&--active {
+							#{$b}:hover & {}
+						}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Accepts relations between the same BEM entity',
+			code: `
+				.block {
+					&__item {
+						&:hover + & {}
+						& & {}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Does not treat a contextual root block declaration as a side-effect',
+			code: `html .block {}`,
+		},
+		{
+			description: 'Uses the most specific modifier in a compound owner',
+			code: `
+				.block__item.block__item--active {
+					.block:hover & {}
+				}
+			`,
+		},
+		{
+			description: 'Treats a modifier value as part of the owner',
+			code: `
+				.block__item--theme--dark {
+					.block:hover & {}
+				}
+			`,
+		},
+		{
+			description: 'Keeps target ownership through `@at-root` and `@nest`',
+			code: `
+				.block__label {
+					@at-root .block__link:hover & {}
+					@nest .block__link:focus & {}
+				}
+			`,
+		},
+		{
+			description: 'Does not repeat an inherited side-effect for nested states',
+			code: `
+				.block__label {
+					.block__link:hover & {
+						&:focus {}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Ignores non-BEM and ambiguous targets',
+			code: `
+				.block__link {
+					&:hover span {}
+					&:hover .is-active {}
+					&:hover :is(.block__label, .block__icon) {}
+				}
+			`,
+		},
+		{
+			description: 'Ignores unresolved interpolation',
+			code: `
+				.block__link {
+					&:hover #{$unknown} {}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports the issue example with styles owned by the source element',
+			code: `
+				.block {
+					$b: #{&};
+
+					&__link {
+						&:hover #{$b}__label {}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 5, column: 11,
+					endLine: 5, endColumn: 23,
+				},
+			],
+		},
+		{
+			description: 'Reports an element nested within a block state',
+			code: `
+				.block {
+					&:hover {
+						.block__label {}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block'),
+					line: 3, column: 3,
+					endLine: 3, endColumn: 16,
+				},
+			],
+		},
+		{
+			description: 'Requires modifier styles to be nested within the modifier',
+			code: `
+				.block {
+					$b: #{&};
+
+					&__item {
+						#{$b}:hover &--active {}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__item--active', '.block__item'),
+					line: 5, column: 15,
+					endLine: 5, endColumn: 24,
+				},
+			],
+		},
+		{
+			description: 'Requires base element styles to leave modifier ownership',
+			code: `
+				.block__item--active {
+					&:hover .block__item {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__item', '.block__item--active'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 22,
+				},
+			],
+		},
+		{
+			description: 'Reports detached flat side-effects',
+			code: `
+				.block__link:hover .block__label {}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', undefined),
+					line: 1, column: 20,
+					endLine: 1, endColumn: 33,
+				},
+			],
+		},
+		{
+			description: 'Does not mistake the first contextual element for a root block definition',
+			code: `.theme:hover .block__label {}`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', undefined),
+					line: 1, column: 14,
+					endLine: 1, endColumn: 27,
+				},
+			],
+		},
+		{
+			description: 'Reports misplaced ownership through `@at-root`',
+			code: `
+				.block__link {
+					@at-root &:hover .block__label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 2, column: 19,
+					endLine: 2, endColumn: 32,
+				},
+			],
+		},
+		{
+			description: 'Reports each misplaced selector-list branch',
+			code: `
+				.block__link {
+					&:hover .block__label,
+					&:focus .block__icon {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 23,
+				},
+				{
+					message: messages.misplaced('.block__icon', '.block__link'),
+					line: 3, column: 10,
+					endLine: 3, endColumn: 22,
+				},
+			],
+		},
+		{
+			description: 'Reports only the authored nested side-effect',
+			code: `
+				.block__link {
+					&:hover .block__label {
+						&:focus {}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 23,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Custom separators',
+	config: [true, {
+		separators: {
+			element: '--',
+			modifier: '_',
+			modifierValue: '_',
+		},
+	}],
+	accept: [
+		{
+			description: 'Recognizes target ownership with custom separators',
+			code: `
+				.block--label {
+					.block--link:hover & {}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports misplaced ownership with custom separators',
+			code: `
+				.block--link {
+					&:hover .block--label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block--label', '.block--link'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 23,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Custom messages',
+	config: [true, {
+		messages: {
+			misplaced: (target: string, owner: string | undefined) => `Move ${target} from ${owner ?? 'root'}`,
+		},
+	}],
+	reject: [
+		{
+			code: `.block {} .block__link:hover .block__label {}`,
+			warnings: [
+				{
+					message: `Move .block__label from root (@morev/bem/no-misplaced-side-effects)`,
+					line: 1, column: 30,
+					endLine: 1, endColumn: 43,
+				},
+			],
+		},
+	],
+});
+
+testCssRule({
+	description: 'Native CSS nesting',
+	config: [true],
+	accept: [
+		{
+			description: 'Accepts target-owned CSS nesting',
+			codeFilename: 'block.css',
+			code: `
+				.block__label {
+					.block__link:hover & {}
+				}
+			`,
+		},
+		{
+			description: 'Keeps ownership through nested group rules',
+			codeFilename: 'block.css',
+			code: `
+				@media (width >= 320px) {
+					.block__label {
+						.block__link:hover & {}
+					}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports misplaced native CSS nesting',
+			codeFilename: 'block.css',
+			code: `
+				.block__link {
+					&:hover .block__label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.misplaced('.block__label', '.block__link'),
+					line: 2, column: 10,
+					endLine: 2, endColumn: 23,
+				},
+			],
+		},
+	],
+});

--- a/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.docs.md
+++ b/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.docs.md
@@ -1,0 +1,312 @@
+# @morev/bem/no-misplaced-side-effects
+
+Requires BEM side-effects to be declared within the entity they affect.
+
+```scss
+.block {
+  $b: #{&};
+
+  &__link {
+    // ❌ Styles for `label` are owned by `link`.
+    &:hover #{$b}__label {} // [!code error]
+  }
+
+  &__icon {
+    // ✅ The target `icon` owns its reaction to `button`.
+    #{$b}__button:hover & {}
+  }
+}
+```
+
+## Motivation
+
+Contextual selectors often express that the state of one entity changes another entity.
+It may feel natural to declare such a relation next to its source —
+for example, to place label styles inside a link because `:hover` on the link triggers them.
+
+```scss
+.block__label {
+  color: black;
+}
+
+.block__link {
+  &:hover .block__label { // [!code error]
+    color: red;
+  }
+}
+```
+
+However, this scatters styles targeting the label across declarations owned by other entities.
+
+A BEM entity should be self-contained: once a developer finds its declaration,
+they should be able to trust that all of its states and contextual reactions are located nearby, inside that entity.
+
+```scss
+.block__label {
+  color: black;
+
+  .block__link:hover & { // [!code focus]
+    color: red;
+  }
+}
+```
+
+Reading, changing, or removing it then does not require searching through sibling entities
+for additional selectors that happen to target it.
+
+This follows the same locality principle as
+[`@morev/base/no-selectors-in-at-rules`](../base/no-selectors-in-at-rules):
+that rule keeps conditional declarations inside the selector they modify,
+while this rule keeps cross-entity reactions inside the BEM entity they modify.
+In both cases, finding the entity once gives you one predictable place to understand and edit its behavior.
+
+```scss{6-9}
+// All states and contextual reactions are colocated in one declaration.
+// Find the entity once to see its complete behavior in every supported context.
+.block__label {
+  color: black;
+
+  // Relational state: another BEM entity changes this entity.
+  .block__link:hover & {
+    color: red;
+  }
+
+  // Local state: the entity reacts to its own interaction.
+  &:hover {
+    color: blue;
+  }
+
+  // DOM state: application state exposed through an attribute.
+  &[aria-current='true'] {
+    font-weight: 700;
+  }
+
+  // Environmental context: the viewport changes the entity's presentation.
+  @media (width >= 768px) {
+    font-size: 1.25rem;
+  }
+
+  // Capability context: the browser supports an enhanced presentation.
+  @supports (text-wrap: balance) {
+    text-wrap: balance;
+  }
+
+  // Ancestor context: the surrounding theme affects the entity.
+  [data-theme='dark'] & {
+    color: white;
+  }
+}
+```
+
+Explicit ownership also makes refactoring safer:
+removing an entity removes its contextual styles with it instead of leaving stale selectors elsewhere in the component.
+
+The rule complements [`@morev/bem/no-side-effects`](./no-side-effects):
+
+- `no-side-effects` prevents a component file from styling content outside its BEM block;
+- `no-misplaced-side-effects` verifies ownership of relations inside the block.
+
+## Modifiers
+
+Modifiers are independent owners:
+
+```scss
+.block {
+  &__item {
+    // Owns styles for `.block__item`.
+
+    &--active {
+      // Owns styles for `.block__item--active`.
+    }
+  }
+}
+```
+
+In SCSS, a modifier can be nested under its base entity for declaration convenience,
+but it still creates a separate ownership scope.
+Contextual styles targeting the modifier therefore belong inside the modifier:
+
+::: code-group
+
+```scss [❌ Element owns modifier styles]
+.block {
+  &__item {
+    .block:hover &--active {} // [!code error]
+  }
+}
+```
+
+```scss [✅ Modifier owns its styles]
+.block {
+  &__item {
+    &--active {
+      .block:hover & {}
+    }
+  }
+}
+```
+
+:::
+
+## CSS mechanics
+
+With native CSS Nesting, the surrounding BEM entity owns the styles applied by a nested relation.
+Native nesting does not concatenate identifiers.
+An element or modifier therefore uses its full BEM selector as the outer owner:
+
+```css
+.block__item--active {
+  .block:hover & {}
+}
+```
+
+Flat relational selectors have no owner and are rejected:
+
+```css
+.block__link:hover .block__label {} /* ❌ */
+```
+
+## Rule options
+
+All options are optional and come with recommended default values.
+
+::: code-group
+
+```js [Enabling a rule without options]
+// 📄 .stylelintrc.js
+
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-misplaced-side-effects': true,
+  }
+}
+```
+
+```js [Enabling a rule with custom options]
+// 📄 .stylelintrc.js
+
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-misplaced-side-effects': [true, {
+      separators: {
+        element: '__',
+        modifier: '--',
+        modifierValue: '--',
+      },
+      messages: {
+        misplaced: (target, owner) =>
+          `Move ${target} from ${owner ?? 'root'} into its own styles.`,
+      },
+    }],
+  },
+}
+```
+
+:::
+
+::: details Show full type of the options
+
+```ts
+export type NoMisplacedSideEffectsOptions = {
+  /**
+   * Object that defines BEM separators used to distinguish blocks, elements, modifiers, and modifier values. \
+   * This allows the rule to work correctly with non-standard BEM naming conventions.
+   */
+  separators?: {
+    /**
+     * String used as the BEM element separator.
+     *
+     * @default '__'
+     */
+    element?: string;
+
+    /**
+     * String used as the BEM modifier separator.
+     *
+     * @default '--'
+     */
+    modifier?: string;
+
+    /**
+     * String used as the BEM modifier value separator.
+     *
+     * @default '--'
+     */
+    modifierValue?: string;
+  }
+
+  /**
+   * Custom message functions for rule violations.
+   * If provided, overrides the default error messages.
+   */
+  messages?: {
+    /**
+     * Custom message for styles declared outside their target BEM entity.
+     *
+     * @param   target   Target BEM entity.
+     * @param   owner    BEM entity that currently owns the styles, or `undefined` for a detached selector.
+     *
+     * @returns          The error message to report.
+     */
+    misplaced?: (target: string, owner: string | undefined) => string;
+  };
+}
+```
+
+:::
+
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
+---
+
+### `separators`
+
+<!-- @include: @/docs/_parts/separators.md#header -->
+
+---
+
+### `messages`
+
+<!-- @include: @/docs/_parts/custom-messages.md#header -->
+
+The message function receives the target BEM entity and the entity that currently owns its styles. \
+For detached top-level selectors, `owner` is `undefined`.
+
+#### Example
+
+```js
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-misplaced-side-effects': [true, {
+      messages: {
+        misplaced: (target, owner) => owner
+          ? `⛔ Move "${target}" from "${owner}" into its own styles.`
+          : `⛔ Move "${target}" into its own styles.`,
+      },
+    }],
+  },
+}
+```
+
+::: details Show function signature
+
+```ts
+export type MessagesOption = {
+  /**
+   * Custom message for styles declared outside their target BEM entity.
+   *
+   * @param   target   Target BEM entity.
+   * @param   owner    BEM entity that currently owns the styles, or `undefined` for a detached selector.
+   *
+   * @returns          The error message to report.
+   */
+  misplaced?: (target: string, owner: string | undefined) => string;
+};
+```
+
+:::
+
+<!-- @include: @/docs/_parts/custom-messages.md#formatting -->

--- a/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
+++ b/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
@@ -140,7 +140,7 @@ export default createRule({
 		// Selector lists and parent selector lists expand into separate resolved branches.
 		// Each misplaced target is checked independently, e.g.
 		// `.block__link { &:hover .block__label, &:focus .block__icon {} }`.
-		resolveSelectorNodes({ node }).forEach(({ parent, replacements, resolved, source }) => {
+		resolveSelectorNodes({ node }).forEach(({ lexicalParent, replacements, resolved, source }) => {
 			const resolvedSelector = selectorNodesToString(resolved);
 			// Unknown interpolation such as `#{$unknown}` cannot provide a reliable BEM target.
 			if (resolvedSelector.includes('#{')) return;
@@ -191,13 +191,14 @@ export default createRule({
 				&& isEmpty(sourceEntities)
 			) return;
 
-			// The resolved parent represents the selector that lexically owns this declaration:
+			// The lexical parent represents the selector that owns this declaration:
 			// `.block__label { .block:hover & {} }` is owned by `.block__label`,
 			// while `.block__link { &:hover .block__label {} }` is owned by `.block__link`.
-			// A flat `.block__link:hover .block__label {}` has no owner.
-			const ownerEntities = parent
+			// It remains `.block__label` through `@at-root`, even when no parent context
+			// participates in the emitted selector. A flat relation still has no owner.
+			const ownerEntities = lexicalParent
 				? getMostSpecificEntities(
-					splitCompounds(parent).at(-1) ?? [],
+					splitCompounds(lexicalParent).at(-1) ?? [],
 					bemBlock.blockName,
 					separators,
 				)
@@ -205,7 +206,7 @@ export default createRule({
 
 			// A parent such as `:is(.block__label, .block__icon)` has no unambiguous owner
 			// and is outside this rule's ownership model.
-			if (parent && ownerEntities.length !== 1) return;
+			if (lexicalParent && ownerEntities.length !== 1) return;
 
 			const owner = ownerEntities[0];
 			if (owner === target) return;

--- a/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
+++ b/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
@@ -1,0 +1,227 @@
+import { arrayUnique, isEmpty } from '@morev/utils';
+import * as v from 'valibot';
+import { getBemBlock, isDirectBemEntity, resolveBemEntities } from '#modules/bem';
+import { isAtRule, isKeyframesRule, isRule } from '#modules/postcss';
+import { createRule, extractSeparators, mergeMessages, vMessagesSchema, vSeparatorsSchema } from '#modules/rule-utils';
+import { getResolvedNodesSourceRange, resolveSelectorNodes, selectorNodesToString } from '#modules/selectors';
+import type parser from 'postcss-selector-parser';
+import type { BemEntity } from '#modules/bem';
+import type { Separators } from '#modules/shared';
+
+/**
+ * Splits a flat selector branch at top-level combinators.
+ * For example, `.block:hover > .block__label` becomes two compounds:
+ * `.block:hover` and `.block__label`.
+ *
+ * Combinators inside functional pseudos remain part of their containing node,
+ * so `:has(.foo .bar)` is not split here.
+ *
+ * @param   nodes   Parsed selector nodes from one branch.
+ *
+ * @returns         Non-empty compounds in source order.
+ */
+const splitCompounds = <Node extends parser.Node>(nodes: Node[]) => {
+	const compounds: Node[][] = [[]];
+
+	for (const node of nodes) {
+		if (node.type === 'combinator') {
+			compounds.push([]);
+			continue;
+		}
+
+		compounds.at(-1)!.push(node);
+	}
+
+	return compounds.filter((compound) => !isEmpty(compound));
+};
+
+/**
+ * Ranks a BEM entity by the number of parts after its block.
+ * For example, `.block` has rank 0, `.block__item` has rank 1,
+ * and `.block__item--active` has rank 2.
+ *
+ * @param   entity   Resolved BEM entity.
+ *
+ * @returns          Structural depth of the entity.
+ */
+const getEntitySpecificity = (entity: BemEntity) => {
+	return [entity.element, entity.modifierName, entity.modifierValue]
+		.filter(Boolean).length;
+};
+
+/**
+ * Resolves the deepest direct BEM entities of the requested block in a compound.
+ * For `.block__item.block__item--active:hover`, only
+ * `.block__item--active` is returned and treated as the owner.
+ *
+ * Entities nested inside functional pseudos are contextual conditions rather than owners.
+ * For example, `.block:is(.block__item)` is owned by `.block`, not `.block__item`.
+ *
+ * @param   nodes        Nodes of one selector compound.
+ * @param   blockName    BEM block whose entities may participate in ownership.
+ * @param   separators   Separators used to parse BEM entities.
+ *
+ * @returns              Unique selectors at the greatest structural depth.
+ */
+const getMostSpecificEntities = (
+	nodes: parser.Node[],
+	blockName: string,
+	separators: Separators,
+) => {
+	const selector = selectorNodesToString(nodes);
+	const entities = resolveBemEntities({ source: selector, separators })
+		.filter((entity) => entity.block.value === blockName)
+		.filter(isDirectBemEntity);
+	if (isEmpty(entities)) return [];
+
+	const highestSpecificity = Math.max(...entities.map((entity) => getEntitySpecificity(entity)));
+	return arrayUnique(
+		entities
+			.filter((entity) => getEntitySpecificity(entity) === highestSpecificity)
+			.map((entity) => entity.bemSelector),
+	);
+};
+
+/**
+ * Recursively checks for an authored nesting selector.
+ * Recursion covers cases such as `:is(&:hover, .is-active)`.
+ *
+ * @param   nodes   Parsed nodes of the authored selector.
+ *
+ * @returns         Whether the selector contains a raw `&` at any depth.
+ */
+const hasNesting = (nodes: parser.Node[]): boolean => {
+	return nodes.some((node) => {
+		if (node.type === 'nesting') return true;
+		if (!('nodes' in node) || isEmpty(node.nodes)) return false;
+
+		return node.nodes.some((child) => hasNesting([child]));
+	});
+};
+
+export default createRule({
+	scope: 'bem',
+	name: 'no-misplaced-side-effects',
+	meta: {
+		description: 'Requires BEM side-effects to be declared within the entity they affect.',
+		deprecated: false,
+		fixable: false,
+	},
+	messages: {
+		misplaced: (target: string, owner: string | undefined) => owner
+			? `Expected side-effect on "${target}" to be declared within its own styles, but found within "${owner}"`
+			: `Expected side-effect on "${target}" to be declared within its own styles`,
+	},
+	schema: {
+		primary: v.literal(true),
+		secondary: v.optional(
+			v.object({
+				separators: vSeparatorsSchema,
+				messages: vMessagesSchema({
+					misplaced: [v.string(), v.union([v.string(), v.undefined()])],
+				}),
+			}),
+		),
+	},
+}, (primary, secondary, { report, messages: ruleMessages, root }) => {
+	const messages = mergeMessages(ruleMessages, secondary.messages);
+	const separators = extractSeparators(secondary.separators);
+	const bemBlock = getBemBlock(root, separators);
+	if (!bemBlock) return;
+
+	root.walk((node) => {
+		// Only constructs that can own selectors participate in the rule.
+		// Keyframe steps such as `from` and `50%` must never be interpreted as selector ownership.
+		if (isKeyframesRule(node)) return;
+		if (!isAtRule(node, ['nest', 'at-root']) && !isRule(node)) return;
+
+		const reportedViolations = new Set<string>();
+
+		// Selector lists and parent selector lists expand into separate resolved branches.
+		// Each misplaced target is checked independently, e.g.
+		// `.block__link { &:hover .block__label, &:focus .block__icon {} }`.
+		resolveSelectorNodes({ node }).forEach(({ parent, replacements, resolved, source }) => {
+			const resolvedSelector = selectorNodesToString(resolved);
+			// Unknown interpolation such as `#{$unknown}` cannot provide a reliable BEM target.
+			if (resolvedSelector.includes('#{')) return;
+
+			// A relation needs at least a source and a target compound.
+			// `.block__label:hover` is local state; `.block:hover .block__label` is a relation.
+			const compounds = splitCompounds(resolved);
+			if (compounds.length < 2) return;
+
+			// A nested state may inherit an already-authored relation:
+			// `.block__label { .block:hover & { &:focus {} } }`.
+			// The inner `&:focus` resolves to the same relation but does not author it again.
+			// Keep selectors with their own combinator and implicit descendants such as
+			// `.block__link { .block__label {} }`, represented by a parent injection.
+			const hasSourceCombinator = source.some((sourceNode) => sourceNode.type === 'combinator');
+			const hasParentInjection = replacements.some(({ type }) => type === 'parent-injection');
+			if (!hasSourceCombinator && !hasParentInjection && hasNesting(source)) return;
+
+			// Declarations apply to the rightmost compound.
+			// In `.block__link:hover .block__label`, the target is `.block__label`.
+			const targetCompound = compounds.at(-1)!;
+			const targetEntities = getMostSpecificEntities(
+				targetCompound,
+				bemBlock.blockName,
+				separators,
+			);
+			// Selectors such as `:is(.block__label, .block__icon)` do not have one unambiguous target.
+			if (targetEntities.length !== 1) return;
+
+			const target = targetEntities[0];
+			// Map the resolved target back to its authored fragment, including selector-list offsets.
+			const sourceRange = getResolvedNodesSourceRange(targetCompound);
+			if (!sourceRange) return;
+
+			// Source entities describe the BEM context that affects the target.
+			// For `.block__link:hover .block__label`, this resolves to `.block__link`.
+			const sourceEntities = compounds.slice(0, -1)
+				.flatMap((compound) => getMostSpecificEntities(
+					compound,
+					bemBlock.blockName,
+					separators,
+				));
+			// `html .block` may define the root block without creating a BEM side-effect.
+			// `.theme:hover .block__label` is different: the element is still a detached target.
+			if (
+				node === bemBlock.rule
+				&& target === bemBlock.selector
+				&& isEmpty(sourceEntities)
+			) return;
+
+			// The resolved parent represents the selector that lexically owns this declaration:
+			// `.block__label { .block:hover & {} }` is owned by `.block__label`,
+			// while `.block__link { &:hover .block__label {} }` is owned by `.block__link`.
+			// A flat `.block__link:hover .block__label {}` has no owner.
+			const ownerEntities = parent
+				? getMostSpecificEntities(
+					splitCompounds(parent).at(-1) ?? [],
+					bemBlock.blockName,
+					separators,
+				)
+				: [];
+
+			// A parent such as `:is(.block__label, .block__icon)` has no unambiguous owner
+			// and is outside this rule's ownership model.
+			if (parent && ownerEntities.length !== 1) return;
+
+			const owner = ownerEntities[0];
+			if (owner === target) return;
+
+			// Different resolution paths can converge on the same authored target.
+			// Report every source range and ownership pair only once.
+			const violationKey = ['misplaced', sourceRange.index, sourceRange.endIndex, target, owner].join(':');
+			if (reportedViolations.has(violationKey)) return;
+			reportedViolations.add(violationKey);
+
+			report({
+				...sourceRange,
+				node,
+				message: messages.misplaced(target, owner),
+				messageArgs: ['misplaced', target, owner],
+			});
+		});
+	});
+});

--- a/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
+++ b/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.ts
@@ -198,7 +198,7 @@ export default createRule({
 			// participates in the emitted selector. A flat relation still has no owner.
 			const ownerEntities = lexicalParent
 				? getMostSpecificEntities(
-					splitCompounds(lexicalParent).at(-1) ?? [],
+					splitCompounds(lexicalParent).at(-1)!,
 					bemBlock.blockName,
 					separators,
 				)

--- a/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.types.ts
+++ b/src/rules/bem/no-misplaced-side-effects/no-misplaced-side-effects.types.ts
@@ -1,0 +1,33 @@
+import type { Separators } from '#modules/shared';
+
+/**
+ * Primary option of the rule.
+ */
+export type PrimaryOption = true;
+
+/**
+ * Secondary options of the rule.
+ */
+export type SecondaryOption = {
+	/**
+	 * Object that defines BEM separators used to distinguish blocks, elements, modifiers, and modifier values.
+	 *
+	 * @default { element: '__', modifier: '--', modifierValue: '--' }
+	 */
+	separators?: Partial<Separators>;
+
+	/**
+	 * Custom message functions for rule violations.
+	 */
+	messages?: {
+		/**
+		 * Custom message for styles declared outside their target BEM entity.
+		 *
+		 * @param   target   Target BEM entity.
+		 * @param   owner    BEM entity that currently owns the styles, if any.
+		 *
+		 * @returns          The error message to report.
+		 */
+		misplaced?: (target: string, owner: string | undefined) => string;
+	};
+};

--- a/src/rules/bem/no-side-effects/__tests__/no-side-effects.implementation.test.ts
+++ b/src/rules/bem/no-side-effects/__tests__/no-side-effects.implementation.test.ts
@@ -184,6 +184,27 @@ testRule({
 			],
 		},
 		{
+			description: 'Reports the full source range of a resolved nested selector',
+			code: `
+				.the-component {}
+				.foreign {
+					&--modifier {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.rejected('.foreign'),
+					line: 2, column: 1,
+					endLine: 2, endColumn: 9,
+				},
+				{
+					message: messages.rejected('.foreign--modifier'),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 13,
+				},
+			],
+		},
+		{
 			description: 'Reports inline side-effect',
 			code: `
 				.the-component {}

--- a/src/rules/bem/no-side-effects/utils/create-violations-registry.ts
+++ b/src/rules/bem/no-side-effects/utils/create-violations-registry.ts
@@ -1,5 +1,4 @@
-import { isEmpty } from '@morev/utils';
-import { selectorNodesToString } from '#modules/selectors';
+import { getResolvedNodesSourceRange, selectorNodesToString } from '#modules/selectors';
 import type postcss from 'postcss';
 import type { ResolvedNode } from '#modules/selectors';
 
@@ -82,18 +81,10 @@ export const createViolationsRegistry = (ignoredPatterns: RegExp[]) => {
 		// prevents duplicate violations from nested contexts.
 		if (hasAncestorWithSameSelector(node, selector)) return;
 
-		const sourcePresentedNodes = nodes
-			.filter((resolvedNode) => !isEmpty(resolvedNode.meta.sourceMatches));
-		if (isEmpty(sourcePresentedNodes)) return;
+		const sourceRange = getResolvedNodesSourceRange(nodes);
+		if (!sourceRange) return;
 
-		const [firstMatch, lastMatch] = [
-			sourcePresentedNodes[0].meta.sourceMatches.at(-1)!,
-			sourcePresentedNodes.at(-1)!.meta.sourceMatches[0],
-		];
-		const index = firstMatch.sourceRange[0] + firstMatch.offset;
-		const endIndex = lastMatch.sourceRange[1] + firstMatch.offset;
-
-		violations.push({ node, index, endIndex, selector });
+		violations.push({ node, ...sourceRange, selector });
 
 		let seen = seenBySelector.get(selector);
 		if (!seen) {

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -4,6 +4,7 @@ export { default as blockVariable } from './bem/block-variable/block-variable';
 export { default as matchFileName } from './bem/match-file-name/match-file-name';
 export { default as noBlockProperties } from './bem/no-block-properties/no-block-properties';
 export { default as noChainedEntities } from './bem/no-chained-entities/no-chained-entities';
+export { default as noMisplacedSideEffects } from './bem/no-misplaced-side-effects/no-misplaced-side-effects';
 export { default as noSideEffects } from './bem/no-side-effects/no-side-effects';
 export { default as selectorPattern } from './bem/selector-pattern/selector-pattern';
 

--- a/stylelint.config.ts
+++ b/stylelint.config.ts
@@ -1,8 +1,46 @@
 import { defineConfig } from '@morev/stylelint-config';
+import localPlugin, { createDefineRules } from '@morev/stylelint-plugin';
 
-export default defineConfig({
+const tempFiles = ['temp/**/*.scss', 'temp/**/*.css'];
+const config = defineConfig({
 	preset: 'scss',
 	bem: {
-		files: ['temp/**/*.scss', 'temp/**/*.css'],
+		files: tempFiles,
 	},
 });
+
+const defineLocalRules = createDefineRules();
+const localRuleOverrides = defineLocalRules({
+	'@morev/bem/no-misplaced-side-effects': [true, {}],
+});
+
+const configuredRuleNames = new Set([
+	...Object.keys(config.rules ?? {}),
+	...(config.overrides ?? [])
+		.flatMap(({ rules }) => Object.keys(rules ?? {})),
+]);
+
+const localRuleNames = localPlugin.flatMap((plugin) => (
+	'ruleName' in plugin ? [plugin.ruleName] : []
+));
+
+const automaticallyEnabledRules = Object.fromEntries(
+	localRuleNames
+		.filter((ruleName) => !configuredRuleNames.has(ruleName))
+		.map((ruleName) => [ruleName, true]),
+);
+
+export default {
+	...config,
+	overrides: [
+		...(config.overrides ?? []),
+		{
+			files: tempFiles,
+			plugins: localPlugin,
+			rules: {
+				...automaticallyEnabledRules,
+				...localRuleOverrides,
+			},
+		},
+	],
+};


### PR DESCRIPTION
#### Description

Adds the `@morev/bem/no-misplaced-side-effects` rule, which requires contextual styles to be declared within the BEM entity they affect.

This keeps an entity's base styles, states, and contextual reactions colocated instead of scattering them across sibling entities. Modifiers are treated as independent owners.

The PR also:

- extends `resolveSelectorNodes` with branch-specific parent and replacement metadata;
- extracts shared helpers for direct BEM entities and resolved source ranges;
- fixes report ranges for selectors composed from multiple source fragments;
- covers SCSS and native nesting, selector lists, Sass interpolation and variables, `@nest`, `@at-root`, custom separators, and custom messages;
- adds rule metadata, typed configuration support, tests, and documentation;
- configures the local Stylelint setup to use every local plugin implementation and automatically enable rules missing from the installed shared config.

#### Linked issue

Closes #13