### PR TITLE
feat(bem): Add `no-grouped-entities` rule

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -110,6 +110,7 @@ export default {
           presets: ['EXTERNAL_GEOMETRY', 'CONTEXT_DEPENDENT'], // [!code ++]
         }], // [!code ++]
         '@morev/bem/no-chained-entities': true, // [!code ++]
+        '@morev/bem/no-grouped-entities': true, // [!code ++]
         '@morev/bem/no-misplaced-relational-styles': true, // [!code ++]
         '@morev/bem/no-side-effects': true, // [!code ++]
         '@morev/bem/selector-pattern': true, // [!code ++]
@@ -203,6 +204,7 @@ export default {
           ignoreBlocks: ['*swiper*'],
         }],
         '@morev/bem/no-chained-entities': [true, {}],
+        '@morev/bem/no-grouped-entities': [true, {}],
         '@morev/bem/no-misplaced-relational-styles': [true, {}],
         '@morev/bem/no-side-effects': [true, {
           ignore: [

--- a/src/create-define-rules/create-define-rules.ts
+++ b/src/create-define-rules/create-define-rules.ts
@@ -15,6 +15,7 @@ const rulesWithSeparators = [
 	'@morev/bem/match-file-name',
 	'@morev/bem/no-block-properties',
 	'@morev/bem/no-chained-entities',
+	'@morev/bem/no-grouped-entities',
 	'@morev/bem/no-misplaced-relational-styles',
 	'@morev/bem/no-side-effects',
 	'@morev/bem/selector-pattern',

--- a/src/modules/bem/index.ts
+++ b/src/modules/bem/index.ts
@@ -4,4 +4,5 @@ export * from './utils/get-most-specific-entity-part/get-most-specific-entity-pa
 export * from './utils/is-direct-bem-entity/is-direct-bem-entity';
 export * from './utils/resolve-bem-chain/resolve-bem-chain';
 export * from './utils/resolve-bem-entities/resolve-bem-entities';
+export * from './utils/resolve-most-specific-bem-entities/resolve-most-specific-bem-entities';
 export type * from './types';

--- a/src/modules/bem/utils/resolve-most-specific-bem-entities/resolve-most-specific-bem-entities.test.ts
+++ b/src/modules/bem/utils/resolve-most-specific-bem-entities/resolve-most-specific-bem-entities.test.ts
@@ -1,0 +1,44 @@
+import { DEFAULT_SEPARATORS } from '#modules/bem';
+import { parseSelectors } from '#modules/selectors';
+import { resolveMostSpecificBemEntities } from './resolve-most-specific-bem-entities';
+
+const resolve = (selector: string, blockName?: string) => {
+	const [nodes] = parseSelectors(selector);
+
+	return resolveMostSpecificBemEntities({
+		blockName,
+		nodes,
+		separators: DEFAULT_SEPARATORS,
+	}).map((entity) => entity.bemSelector);
+};
+
+describe(resolveMostSpecificBemEntities, () => {
+	it('Returns the deepest direct BEM entity', () => {
+		expect(resolve('.block__item.block__item--active:hover'))
+			.toStrictEqual(['.block__item--active']);
+	});
+
+	it('Returns distinct entities at the same depth', () => {
+		expect(resolve('.block__item.other__item'))
+			.toStrictEqual(['.block__item', '.other__item']);
+	});
+
+	it('Deduplicates equivalent BEM entities', () => {
+		expect(resolve('.block__item.block__item'))
+			.toStrictEqual(['.block__item']);
+	});
+
+	it('Excludes BEM entities nested inside functional pseudo-classes', () => {
+		expect(resolve('.block:is(.block__item)'))
+			.toStrictEqual(['.block']);
+	});
+
+	it('Applies the block filter before comparing entity depth', () => {
+		expect(resolve('.other__item--active.block__item', 'block'))
+			.toStrictEqual(['.block__item']);
+	});
+
+	it('Returns an empty list when the compound has no matching BEM entity', () => {
+		expect(resolve('.other__item', 'block')).toStrictEqual([]);
+	});
+});

--- a/src/modules/bem/utils/resolve-most-specific-bem-entities/resolve-most-specific-bem-entities.ts
+++ b/src/modules/bem/utils/resolve-most-specific-bem-entities/resolve-most-specific-bem-entities.ts
@@ -1,0 +1,63 @@
+import { isEmpty } from '@morev/utils';
+import { isDirectBemEntity } from '#modules/bem/utils/is-direct-bem-entity/is-direct-bem-entity';
+import { resolveBemEntities } from '#modules/bem/utils/resolve-bem-entities/resolve-bem-entities';
+import { selectorNodesToString } from '#modules/selectors';
+import type parser from 'postcss-selector-parser';
+import type { BemEntity } from '#modules/bem/types';
+import type { Separators } from '#modules/shared';
+
+type Options = {
+	/**
+	 * Optional block whose entities may participate in the result.
+	 */
+	blockName?: string;
+
+	/**
+	 * Nodes of one selector compound.
+	 */
+	nodes: parser.Node[];
+
+	/**
+	 * Separators used to parse BEM entities.
+	 */
+	separators: Separators;
+};
+
+/**
+ * Ranks a BEM entity by the number of parts after its block.
+ *
+ * @param   entity   Resolved BEM entity.
+ *
+ * @returns          Structural depth of the entity.
+ */
+const getEntityDepth = (entity: BemEntity) => {
+	return [entity.element, entity.modifierName, entity.modifierValue]
+		.filter(Boolean).length;
+};
+
+/**
+ * Resolves the deepest direct BEM entities from one selector compound.
+ * Entities nested inside functional pseudo-classes are excluded.
+ *
+ * @param   options   Selector nodes, BEM separators, and an optional block filter.
+ *
+ * @returns           Unique entities at the greatest structural depth.
+ */
+export const resolveMostSpecificBemEntities = (options: Options) => {
+	const { blockName, nodes, separators } = options;
+	const entities = resolveBemEntities({
+		source: selectorNodesToString(nodes),
+		separators,
+	}).filter(isDirectBemEntity)
+		.filter((entity) => blockName === undefined || entity.block.value === blockName);
+
+	if (isEmpty(entities)) return [];
+
+	const greatestDepth = Math.max(...entities.map((entity) => getEntityDepth(entity)));
+	const mostSpecificEntities = entities
+		.filter((entity) => getEntityDepth(entity) === greatestDepth);
+
+	return [...new Map(
+		mostSpecificEntities.map((entity) => [entity.bemSelector, entity]),
+	).values()];
+};

--- a/src/modules/meta/__generated__/rules-meta.ts
+++ b/src/modules/meta/__generated__/rules-meta.ts
@@ -43,6 +43,16 @@ export const rulesMeta = [
 		vitepressLink: '/rules/bem/no-misplaced-relational-styles.html',
 	},
 	{
+		id: '@morev/bem/no-grouped-entities',
+		scope: 'bem',
+		name: 'no-grouped-entities',
+		description: 'Prevents BEM entities from having both grouped and separate declarations.',
+		fixable: false,
+		docsPath: 'src/rules/bem/no-grouped-entities/no-grouped-entities.docs.md',
+		vitepressPath: '/rules/bem/no-grouped-entities.md',
+		vitepressLink: '/rules/bem/no-grouped-entities.html',
+	},
+	{
 		id: '@morev/bem/no-chained-entities',
 		scope: 'bem',
 		name: 'no-chained-entities',
@@ -156,6 +166,16 @@ export const scopedRulesMeta = [
 				docsPath: 'src/rules/bem/no-chained-entities/no-chained-entities.docs.md',
 				vitepressPath: '/rules/bem/no-chained-entities.md',
 				vitepressLink: '/rules/bem/no-chained-entities.html',
+			},
+			{
+				id: '@morev/bem/no-grouped-entities',
+				scope: 'bem',
+				name: 'no-grouped-entities',
+				description: 'Prevents BEM entities from having both grouped and separate declarations.',
+				fixable: false,
+				docsPath: 'src/rules/bem/no-grouped-entities/no-grouped-entities.docs.md',
+				vitepressPath: '/rules/bem/no-grouped-entities.md',
+				vitepressLink: '/rules/bem/no-grouped-entities.html',
 			},
 			{
 				id: '@morev/bem/no-misplaced-relational-styles',

--- a/src/modules/meta/__generated__/rules-schema.ts
+++ b/src/modules/meta/__generated__/rules-schema.ts
@@ -7,6 +7,7 @@ import type * as blockVariable from '#rules/bem/block-variable/block-variable.ty
 import type * as matchFileName from '#rules/bem/match-file-name/match-file-name.types';
 import type * as noBlockProperties from '#rules/bem/no-block-properties/no-block-properties.types';
 import type * as noChainedEntities from '#rules/bem/no-chained-entities/no-chained-entities.types';
+import type * as noGroupedEntities from '#rules/bem/no-grouped-entities/no-grouped-entities.types';
 import type * as noMisplacedRelationalStyles from '#rules/bem/no-misplaced-relational-styles/no-misplaced-relational-styles.types';
 import type * as noSideEffects from '#rules/bem/no-side-effects/no-side-effects.types';
 import type * as selectorPattern from '#rules/bem/selector-pattern/selector-pattern.types';
@@ -41,6 +42,13 @@ export type RulesSchema = {
 	 * @see https://morevm.github.io/stylelint-plugin/rules/bem/no-misplaced-relational-styles.html
 	 */
 	'@morev/bem/no-misplaced-relational-styles': RuleSetting<noMisplacedRelationalStyles.PrimaryOption, noMisplacedRelationalStyles.SecondaryOption>;
+
+	/**
+	 * Prevents BEM entities from having both grouped and separate declarations.
+	 *
+	 * @see https://morevm.github.io/stylelint-plugin/rules/bem/no-grouped-entities.html
+	 */
+	'@morev/bem/no-grouped-entities': RuleSetting<noGroupedEntities.PrimaryOption, noGroupedEntities.SecondaryOption>;
 
 	/**
 	 * Disallows splitting BEM entities across multiple chained `&` selectors in SCSS.

--- a/src/modules/postcss/index.ts
+++ b/src/modules/postcss/index.ts
@@ -7,4 +7,5 @@ export * from './is-keyframes-rule/is-keyframes-rule';
 export * from './is-pseudo-element-node/is-pseudo-element-node';
 export * from './is-rule/is-rule';
 export * from './is-same-node/is-same-node';
+export * from './is-selector-owner-node/is-selector-owner-node';
 export * from './resolve-sass-variable/resolve-sass-variable';

--- a/src/modules/postcss/is-selector-owner-node/is-selector-owner-node.test.ts
+++ b/src/modules/postcss/is-selector-owner-node/is-selector-owner-node.test.ts
@@ -1,0 +1,25 @@
+import { AtRule, Declaration, Rule } from 'postcss';
+import { isSelectorOwnerNode } from './is-selector-owner-node';
+
+describe(isSelectorOwnerNode, () => {
+	it('Accepts ordinary CSS rules', () => {
+		expect(isSelectorOwnerNode(new Rule({ selector: '.block' }))).toBe(true);
+	});
+
+	it.each(['nest', 'at-root'])('Accepts @%s rules', (name) => {
+		expect(isSelectorOwnerNode(new AtRule({ name }))).toBe(true);
+	});
+
+	it('Rejects unrelated at-rules and declarations', () => {
+		expect(isSelectorOwnerNode(new AtRule({ name: 'media' }))).toBe(false);
+		expect(isSelectorOwnerNode(new Declaration({ prop: 'color', value: 'red' }))).toBe(false);
+	});
+
+	it('Rejects keyframe steps', () => {
+		const keyframes = new AtRule({ name: 'keyframes' });
+		const step = new Rule({ selector: 'from' });
+		keyframes.append(step);
+
+		expect(isSelectorOwnerNode(step)).toBe(false);
+	});
+});

--- a/src/modules/postcss/is-selector-owner-node/is-selector-owner-node.ts
+++ b/src/modules/postcss/is-selector-owner-node/is-selector-owner-node.ts
@@ -1,0 +1,17 @@
+import { isAtRule } from '#modules/postcss/is-at-rule/is-at-rule';
+import { isKeyframesRule } from '#modules/postcss/is-keyframes-rule/is-keyframes-rule';
+import { isRule } from '#modules/postcss/is-rule/is-rule';
+import type { AtRule, ChildNode, Rule } from 'postcss';
+
+/**
+ * Checks whether a PostCSS node owns a selector that can be resolved.
+ *
+ * @param   node   PostCSS child node to inspect.
+ *
+ * @returns        Whether the node is a rule, `@nest`, or `@at-root` selector owner.
+ */
+export const isSelectorOwnerNode = (node: ChildNode): node is AtRule | Rule => {
+	if (isKeyframesRule(node)) return false;
+
+	return isRule(node) || isAtRule(node, ['nest', 'at-root']);
+};

--- a/src/modules/selectors/index.ts
+++ b/src/modules/selectors/index.ts
@@ -3,4 +3,5 @@ export * from './resolve-nested-selector/resolve-nested-selector';
 export * from './resolve-selector-nodes/resolve-selector-nodes';
 export * from './resolve-selector-nodes/utils/get-resolved-nodes-source-range';
 export * from './selector-nodes-to-string/selector-nodes-to-string';
+export * from './split-selector-compounds/split-selector-compounds';
 export type * from './types';

--- a/src/modules/selectors/split-selector-compounds/split-selector-compounds.test.ts
+++ b/src/modules/selectors/split-selector-compounds/split-selector-compounds.test.ts
@@ -1,0 +1,29 @@
+import { parseSelectors, selectorNodesToString } from '#modules/selectors';
+import { splitSelectorCompounds } from './split-selector-compounds';
+
+const split = (selector: string) => {
+	const [nodes] = parseSelectors(selector);
+
+	return splitSelectorCompounds(nodes).map((compound) => selectorNodesToString(compound));
+};
+
+describe(splitSelectorCompounds, () => {
+	it('Splits a selector at top-level combinators', () => {
+		expect(split('.block:hover > .block__label + .block__icon')).toStrictEqual([
+			'.block:hover',
+			'.block__label',
+			'.block__icon',
+		]);
+	});
+
+	it('Keeps combinators inside functional pseudo-classes', () => {
+		expect(split(':has(.foo .bar) > .block__label')).toStrictEqual([
+			':has(.foo .bar)',
+			'.block__label',
+		]);
+	});
+
+	it('Omits empty compounds around boundary combinators', () => {
+		expect(split('> .block__label >')).toStrictEqual(['.block__label']);
+	});
+});

--- a/src/modules/selectors/split-selector-compounds/split-selector-compounds.ts
+++ b/src/modules/selectors/split-selector-compounds/split-selector-compounds.ts
@@ -1,0 +1,25 @@
+import { isEmpty } from '@morev/utils';
+import type parser from 'postcss-selector-parser';
+
+/**
+ * Splits a flat selector branch at top-level combinators.
+ * Combinators inside functional pseudo-classes remain part of their containing node.
+ *
+ * @param   nodes   Parsed selector nodes from one branch.
+ *
+ * @returns         Non-empty compounds in source order.
+ */
+export const splitSelectorCompounds = <Node extends parser.Node>(nodes: Node[]) => {
+	const compounds: Node[][] = [[]];
+
+	for (const node of nodes) {
+		if (node.type === 'combinator') {
+			compounds.push([]);
+			continue;
+		}
+
+		compounds.at(-1)!.push(node);
+	}
+
+	return compounds.filter((compound) => !isEmpty(compound));
+};

--- a/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.configuration.test.ts
+++ b/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.configuration.test.ts
@@ -1,0 +1,115 @@
+import rule from '../no-grouped-entities';
+
+const { ruleName } = rule;
+const testRuleConfig = createTestRuleConfig({ ruleName });
+
+testRuleConfig({
+	description: 'Primary option',
+	accept: [
+		{ description: 'Enabled rule', config: true },
+		{ description: 'Skipped rule', config: null },
+	],
+	reject: [
+		{ config: false },
+		{ config: 'always' },
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary options object',
+	accept: [
+		{ description: 'No value', config: [true] },
+		{ description: 'Empty object', config: [true, {}] },
+	],
+	reject: [
+		{ description: 'Secondary is not an object', config: [true, 'always'] },
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary option > strict',
+	accept: [
+		{
+			description: 'Single-owner behavior',
+			config: [true, { strict: false }],
+		},
+		{
+			description: 'Strict behavior',
+			config: [true, { strict: true }],
+		},
+	],
+	reject: [
+		{
+			description: 'Non-boolean value',
+			config: [true, { strict: 'always' }],
+		},
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary option > messages',
+	accept: [
+		{
+			config: [true, {
+				messages: {
+					grouped: () => '',
+					redeclared: () => '',
+				},
+			}],
+		},
+	],
+	reject: [
+		{
+			config: [true, {
+				messages: {
+					grouped: 1,
+				},
+			}],
+		},
+		{
+			config: [true, {
+				messages: {
+					redeclared: 1,
+				},
+			}],
+		},
+		{
+			config: [true, {
+				messages: {
+					unknown: () => '',
+				},
+			}],
+		},
+	],
+});
+
+testRuleConfig({
+	description: 'Secondary option > separators',
+	accept: [
+		{
+			config: [true, {
+				separators: {
+					element: '__',
+					modifier: '--',
+					modifierValue: '--',
+				},
+			}],
+		},
+	],
+	reject: [
+		{
+			config: [true, {
+				separators: {
+					element: 1,
+				},
+			}],
+		},
+		{
+			config: [true, {
+				separators: {
+					unknown: '__',
+				},
+			}],
+		},
+	],
+});

--- a/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.implementation.test.ts
+++ b/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.implementation.test.ts
@@ -217,6 +217,13 @@ testRule({
 			`,
 		},
 		{
+			description: 'Ignores nested selector lists inside functional pseudo-classes',
+			code: `
+				.block:nth-child(2n of :is(.block__title, .block__label)),
+				.block__item {}
+			`,
+		},
+		{
 			description: 'Ignores unresolved interpolation and ambiguous targets',
 			code: `
 				.block {

--- a/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.implementation.test.ts
+++ b/src/rules/bem/no-grouped-entities/__tests__/no-grouped-entities.implementation.test.ts
@@ -1,0 +1,492 @@
+import rule from '../no-grouped-entities';
+
+const { ruleName, messages } = rule;
+const testRule = createTestRule({ ruleName, customSyntax: 'postcss-scss' });
+const testCssRule = createTestRule({ ruleName });
+
+testRule({
+	description: 'Default ownership behavior',
+	config: [true],
+	accept: [
+		{
+			description: 'Allows a group while it is the only declaration owner',
+			code: `
+				.block {
+					&__title,
+					&__label {}
+				}
+			`,
+		},
+		{
+			description: 'Allows selector owners nested inside the original group',
+			code: `
+				.block {
+					&__title,
+					&__label {
+						&:hover {}
+
+						@media (width > 640px) {
+							&:focus-visible {}
+						}
+
+						@at-root .theme-dark & {}
+					}
+				}
+			`,
+		},
+		{
+			description: 'Treats complete BEM identities as separate entities',
+			code: `
+				.block {
+					&__item,
+					&__item--active {}
+
+					&__item--disabled {}
+				}
+			`,
+		},
+		{
+			description: 'Ignores unresolved and ambiguous external selectors',
+			code: `
+				.block {
+					&__title,
+					&__label {}
+
+					#{$unknown}__title {}
+					&__title.foo__title {}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports a grouped entity and references its later sibling owner',
+			code: `
+				.block {
+					&__title,
+					&__label {}
+
+					&__title:hover {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__title', 5),
+					line: 2, column: 2,
+					endLine: 2, endColumn: 10,
+				},
+			],
+		},
+		{
+			description: 'Reports a grouped entity owned in a sibling conditional rule',
+			code: `
+				.block {
+					&__title,
+					&__label {}
+
+					@media (width > 640px) {
+						&__label {}
+					}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__label', 6),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 10,
+				},
+			],
+		},
+		{
+			description: 'Reports the grouped branch and references its earlier separate owner',
+			code: `
+				.block {
+					&__title {}
+
+					&__title,
+					&__label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__title', 2),
+					line: 4, column: 2,
+					endLine: 4, endColumn: 10,
+				},
+			],
+		},
+		{
+			description: 'Reports an entity shared by overlapping groups in both groups',
+			code: `
+				.block {
+					&__title,
+					&__label {}
+
+					&__label,
+					&__icon {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__label', 5),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 10,
+				},
+				{
+					message: messages.redeclared('.block__label', 3),
+					line: 5, column: 2,
+					endLine: 5, endColumn: 10,
+				},
+			],
+		},
+		{
+			description: 'Reports the repeated complete modifier identity',
+			code: `
+				.block {
+					&__item,
+					&__item--active {}
+
+					&__item--active:hover {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__item--active', 5),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 17,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Strict behavior',
+	config: [true, { strict: true }],
+	accept: [
+		{
+			description: 'Accepts different states and pseudo-elements of one entity',
+			code: `
+				.block {
+					&__title:hover,
+					&__title:focus-visible {}
+
+					&__box::before,
+					&__box::after {}
+				}
+			`,
+		},
+		{
+			description: 'Accepts different contexts targeting one entity',
+			code: `
+				.block__link {
+					&:hover,
+					.toolbar:hover & {}
+				}
+
+				button.block__link[aria-current='true'],
+				a.block__link[href] {}
+			`,
+		},
+		{
+			description: 'Uses the rightmost compound as the declaration target',
+			code: `
+				.block__source .block__target,
+				.block__other .block__target {}
+			`,
+		},
+		{
+			description: 'Uses the most specific entity in a compound',
+			code: `
+				.block__item.block__item--active,
+				.block__item--active:hover {}
+			`,
+		},
+		{
+			description: 'Ignores lists without multiple distinct BEM targets',
+			code: `
+				h1, h2 {}
+				.block__title, h2, .block__title:hover {}
+			`,
+		},
+		{
+			description: 'Ignores selector lists inside functional pseudo-classes',
+			code: `
+				.block:is(.block__title, .block__label),
+				.block__item {}
+			`,
+		},
+		{
+			description: 'Ignores unresolved interpolation and ambiguous targets',
+			code: `
+				.block {
+					#{$unknown}, &__title {}
+					&__item.foo__item, &__label {}
+				}
+			`,
+		},
+		{
+			description: 'Ignores keyframe steps',
+			code: `
+				.block {
+					@keyframes pulse {
+						from, to {}
+					}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports different BEM elements grouped in one rule',
+			code: `
+				.block {
+					&__title,
+					&__table-heading {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.block__table-heading', '.block__title'),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 18,
+				},
+			],
+		},
+		{
+			description: 'Does not treat parent selector-list expansion as another authored grouping',
+			code: `
+				.block__item,
+				.block__label {
+					&--active {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.block__label', '.block__item'),
+					line: 2, column: 1,
+					endLine: 2, endColumn: 14,
+				},
+			],
+		},
+		{
+			description: 'Treats modifiers and modifier values as separate owners',
+			code: `
+				.block {
+					&__item,
+					&__item--active,
+					&__item--theme--dark,
+					&__item--theme--light {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.block__item--active', '.block__item'),
+					line: 3, column: 2,
+					endLine: 3, endColumn: 17,
+				},
+				{
+					message: messages.grouped('.block__item--theme--dark', '.block__item'),
+					line: 4, column: 2,
+					endLine: 4, endColumn: 22,
+				},
+				{
+					message: messages.grouped('.block__item--theme--light', '.block__item'),
+					line: 5, column: 2,
+					endLine: 5, endColumn: 23,
+				},
+			],
+		},
+		{
+			description: 'Compares complete identities and reports each later distinct entity once',
+			code: `
+				.alpha__item,
+				.beta__item,
+				.alpha__item:hover,
+				.gamma__item {}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.beta__item', '.alpha__item'),
+					line: 2, column: 1,
+					endLine: 2, endColumn: 12,
+				},
+				{
+					message: messages.grouped('.gamma__item', '.alpha__item'),
+					line: 4, column: 1,
+					endLine: 4, endColumn: 13,
+				},
+			],
+		},
+		{
+			description: 'Maps escaped class names back to their authored ranges',
+			code: `.block__title\\:large, .block__label {}`,
+			warnings: [
+				{
+					message: messages.grouped('.block__label', '.block__title:large'),
+					line: 1, column: 23,
+					endLine: 1, endColumn: 36,
+				},
+			],
+		},
+		{
+			description: 'Resolves known Sass variables and selector-list offsets',
+			code: `
+				.block {
+					$b: #{&};
+
+					#{$b}__title,
+					#{$b}__label {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.block__label', '.block__title'),
+					line: 5, column: 2,
+					endLine: 5, endColumn: 14,
+				},
+			],
+		},
+		{
+			description: 'Checks selector lists authored in at-root and nest rules',
+			code: `
+				.block {
+					@at-root &__title, &__label {}
+					@nest &__icon, &__button {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.grouped('.block__label', '.block__title'),
+					line: 2, column: 21,
+					endLine: 2, endColumn: 29,
+				},
+				{
+					message: messages.grouped('.block__button', '.block__icon'),
+					line: 3, column: 17,
+					endLine: 3, endColumn: 26,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Custom separators',
+	config: [true, {
+		separators: {
+			element: '--',
+			modifier: '_',
+			modifierValue: '_',
+		},
+	}],
+	reject: [
+		{
+			code: `
+				.block--title, .block--label {}
+				.block--title:hover {}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block--title', 2),
+					line: 1, column: 1,
+					endLine: 1, endColumn: 14,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Custom default message',
+	config: [true, {
+		messages: {
+			redeclared: (entity: string, line: number) => `Separate ${entity} from its group at line ${line}`,
+		},
+	}],
+	reject: [
+		{
+			code: `
+				.block__title, .block__label {}
+				.block__title:hover {}
+			`,
+			warnings: [
+				{
+					message: `Separate .block__title from its group at line 2 (@morev/bem/no-grouped-entities)`,
+					line: 1, column: 1,
+					endLine: 1, endColumn: 14,
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	description: 'Custom strict message',
+	config: [true, {
+		strict: true,
+		messages: {
+			grouped: (entity: string, owner: string) => `Separate ${entity} from ${owner}`,
+		},
+	}],
+	reject: [
+		{
+			code: `.block__title, .block__label {}`,
+			warnings: [
+				{
+					message: `Separate .block__label from .block__title (@morev/bem/no-grouped-entities)`,
+					line: 1, column: 16,
+					endLine: 1, endColumn: 29,
+				},
+			],
+		},
+	],
+});
+
+testCssRule({
+	description: 'Native CSS nesting',
+	config: [true],
+	accept: [
+		{
+			description: 'Accepts conditions of one entity',
+			codeFilename: 'block.css',
+			code: `
+				.block__item {
+					&:hover,
+					.toolbar:hover & {}
+				}
+			`,
+		},
+		{
+			description: 'Allows a native CSS group while it is the only owner',
+			codeFilename: 'block.css',
+			code: `
+				.block {
+					& .block__title,
+					& .block__label {}
+				}
+			`,
+		},
+	],
+	reject: [
+		{
+			description: 'Reports an entity with another native CSS owner',
+			codeFilename: 'block.css',
+			code: `
+				.block {
+					& .block__title,
+					& .block__label {}
+
+					& .block__label:hover {}
+				}
+			`,
+			warnings: [
+				{
+					message: messages.redeclared('.block__label', 5),
+					line: 3, column: 4,
+					endLine: 3, endColumn: 17,
+				},
+			],
+		},
+	],
+});

--- a/src/rules/bem/no-grouped-entities/no-grouped-entities.docs.md
+++ b/src/rules/bem/no-grouped-entities/no-grouped-entities.docs.md
@@ -1,0 +1,404 @@
+# @morev/bem/no-grouped-entities
+
+Prevents BEM entities from having both grouped and separate declarations.
+
+::: code-group
+
+```scss [❌ Grouped and separate declarations]
+.block {
+  &__title, // [!code error]
+  &__table-heading {
+    font-weight: 700;
+  }
+
+  &__title { // [!code highlight]
+    font-size: 16px;
+  }
+}
+```
+
+```scss [✅ Independent entity declarations]
+.block {
+  &__title {
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  &__table-heading {
+    font-weight: 700;
+  }
+}
+```
+
+:::
+
+:::: info Default behavior vs `strict`
+By default, different BEM entities may share a selector list **while that group remains their only declaration owner.**
+Enable [`strict`](#strict) to always disallow such groups.
+
+::: code-group
+
+```scss [✅ Default behavior]
+.block {
+  &__title,
+  &__table-heading {
+    font-weight: 700;
+  }
+}
+```
+
+```scss [❌ Strict behavior]
+.block {
+  &__title,
+  &__table-heading { // [!code error]
+    font-weight: 700;
+  }
+}
+```
+
+:::
+::::
+
+## Motivation
+
+Grouping entities is convenient while their declarations are identical.
+It becomes risky when one of them also receives declarations from another rule:
+the entity now has both an individual owner and a shared owner which is easy to miss during changes or removal.
+
+The default behavior reports that transition and points to the affected branch in the original group:
+
+```scss
+.block {
+  // ❌ `title` is reported because it also has a separate owner below.
+  &__title, // [!code error]
+  &__table-heading {
+    font-weight: 700;
+  }
+
+  // This separate declaration turns the valid group into a violation.
+  &__title:hover { // [!code highlight]
+    color: rebeccapurple;
+  }
+}
+```
+
+Nested declarations that apply to the entire group remain **valid**:
+
+```scss
+.block {
+  &__title,
+  &__table-heading {
+    // ✅ Base declarations apply to the entire group.
+    color: rebeccapurple;
+    font-size: 16px;
+    font-weight: 700;
+
+    // ✅ The nested state also applies to the entire group.
+    &:hover { // [!code highlight]
+      color: crimson; // [!code highlight]
+    }
+
+    // ✅ Conditional declarations also apply to the entire group.
+    @media (width > 768px) { // [!code highlight]
+      font-size: 20px; // [!code highlight]
+    }
+  }
+}
+```
+
+## Entity identity
+
+Each BEM entity is identified by its block, element, modifier name, and modifier value.
+Default and strict behavior use this identity differently.
+
+**Default behavior** matches entities in a selector group with declarations outside that group's lexical subtree. \
+**Exact selectors do not have to match:** `.block__title` and `.block__title:hover` both target the same declaration owner.
+
+```scss
+.block {
+  // ❌ `title` also has a separate declaration below.
+  &__title, // [!code error]
+  &__label {
+    color: rebeccapurple;
+  }
+
+  &__title:hover { // [!code highlight]
+    color: crimson;
+  }
+}
+```
+
+**Strict behavior** compares identities within the selector list itself.
+Different elements, modifiers, and modifier values are separate entities,
+so they cannot share a rule in this mode:
+
+```scss
+.block {
+  // ❌ The navigation buttons are distinct declaration owners.
+  &__previous-button,
+  &__next-button { // [!code error]
+    block-size: 32px;
+    inline-size: 32px;
+  }
+}
+```
+
+Different conditions and pseudo-elements of the same entity are not distinct BEM targets,
+so these selector lists remain valid in both modes:
+
+```scss
+.block {
+  // ✅ Different states of `title` target the same entity.
+  &__title:hover,
+  &__title:focus-visible {
+    color: rebeccapurple;
+  }
+
+  // ✅ Pseudo-elements of `box` target the same entity.
+  &__box::before,
+  &__box::after {
+    background-color: currentcolor;
+  }
+
+  // ✅ Different contexts still target the same `link` entity.
+  &__link {
+    &:hover,
+    .toolbar:hover & {
+      text-decoration: underline;
+    }
+  }
+}
+```
+
+The rule resolves SCSS and native CSS nesting and uses the final, rightmost BEM target of each top-level selector-list branch.
+Unresolved interpolation, ambiguous targets, and selector lists nested inside functional pseudo-classes are skipped conservatively.
+
+## Rule options
+
+All options are optional and come with recommended default values.
+
+::: code-group
+
+```js [Enabling a rule without options]
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-grouped-entities': true,
+  },
+}
+```
+
+```js [Enabling a rule with custom options]
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-grouped-entities': [true, {
+      separators: {
+        element: '__',
+        modifier: '--',
+        modifierValue: '--',
+      },
+      strict: true,
+      messages: {
+        redeclared: (entity, line) =>
+          `Declare ${entity} separately; also declared at line ${line}.`,
+        grouped: (entity, owner) =>
+          `Declare ${entity} separately from ${owner}.`,
+      },
+    }],
+  },
+}
+```
+
+:::
+
+::: details Show full type of the options
+
+```ts
+export type NoGroupedEntitiesOptions = {
+  /**
+   * Whether to reject every selector list that targets different BEM entities.
+   * When disabled, grouping is allowed until a grouped entity is declared outside the group's lexical subtree.
+   *
+   * @default false
+   */
+  strict?: boolean;
+
+  /**
+   * Object that defines BEM separators used to distinguish blocks, elements, modifiers, and modifier values. \
+   * This allows the rule to work correctly with non-standard BEM naming conventions.
+   */
+  separators?: {
+    /**
+     * String used as the BEM element separator.
+     *
+     * @default '__'
+     */
+    element?: string;
+
+    /**
+     * String used as the BEM modifier separator.
+     *
+     * @default '--'
+     */
+    modifier?: string;
+
+    /**
+     * String used as the BEM modifier value separator.
+     *
+     * @default '--'
+     */
+    modifierValue?: string;
+  };
+
+  /**
+   * Custom message functions for rule violations.
+   * If provided, overrides the default error messages.
+   */
+  messages?: {
+    /**
+     * Custom message for a grouped BEM entity that is declared outside its selector group.
+     *
+     * @param   entity   Redeclared grouped BEM entity.
+     * @param   line     Line of the matching external declaration.
+     *
+     * @returns          The error message to report.
+     */
+    redeclared?: (entity: string, line: number) => string;
+
+    /**
+     * Custom message for a BEM entity grouped with another declaration owner.
+     *
+     * @param   entity   Grouped BEM entity.
+     * @param   owner    First BEM entity in the selector list.
+     *
+     * @returns          The error message to report.
+     */
+    grouped?: (entity: string, owner: string) => string;
+  };
+}
+```
+
+:::
+
+<!-- @include: @/docs/_parts/stylelint-wide-options.md -->
+
+---
+
+### `strict`
+
+Controls whether every selector list targeting different BEM entities is reported.
+
+#### `false`
+
+Default.
+Allows a selector group until one of its entities is targeted by another rule outside that group's lexical subtree.
+
+```scss
+.block {
+  &__title,
+  &__label {}
+}
+```
+
+```scss
+.block {
+  // ❌ `label` also has a separate declaration owner below.
+  &__title,
+  &__label { // [!code error]
+    color: rebeccapurple;
+  }
+
+  @media (width > 640px) {
+    // This separate declaration turns the group into a violation.
+    &__label { // [!code highlight]
+      color: crimson;
+    }
+  }
+}
+```
+
+#### `true`
+
+Always reports a selector list when its branches target different BEM entities.
+It does not require another declaration of either entity.
+
+```scss
+.block {
+  // ❌ Distinct entities cannot share a declaration owner in strict mode.
+  &__title, // [!code highlight]
+  &__label { // [!code error]
+    color: rebeccapurple;
+  }
+}
+```
+
+Use this option when each BEM entity must have an independent rule even if declarations have to be duplicated or extracted into a mixin.
+
+---
+
+### `separators`
+
+<!-- @include: @/docs/_parts/separators.md#header -->
+
+---
+
+### `messages`
+
+<!-- @include: @/docs/_parts/custom-messages.md#header -->
+
+The rule exposes a separate message function for each `strict` value:
+
+- `redeclared(entity, line)` is used when `strict` is disabled
+  and receives the entity targeted by both a selector group and an external owner,
+  along with the line of that external occurrence;
+- `grouped(entity, owner)` is used when `strict` is enabled
+  and receives the later distinct entity and the first entity in the selector list.
+
+#### Example
+
+```js
+export default {
+  plugins: ['@morev/stylelint-plugin'],
+  rules: {
+    '@morev/bem/no-grouped-entities': [true, {
+      messages: {
+        redeclared: (entity, line) =>
+          `⛔ Declare "${entity}" separately; also declared at line ${line}.`,
+        grouped: (entity, owner) =>
+          `⛔ Declare "${entity}" separately from "${owner}".`,
+      },
+    }],
+  },
+}
+```
+
+::: details Show function signature
+
+```ts
+export type MessagesOption = {
+  /**
+   * Custom message for a grouped BEM entity that is declared outside its selector group.
+   *
+   * @param   entity   Redeclared grouped BEM entity.
+   * @param   line     Line of the matching external declaration.
+   *
+   * @returns          The error message to report.
+   */
+  redeclared?: (entity: string, line: number) => string;
+
+  /**
+   * Custom message for a BEM entity grouped with another declaration owner.
+   *
+   * @param   entity   Grouped BEM entity.
+   * @param   owner    First BEM entity in the selector list.
+   *
+   * @returns          The error message to report.
+   */
+  grouped?: (entity: string, owner: string) => string;
+};
+```
+
+:::
+
+<!-- @include: @/docs/_parts/custom-messages.md#formatting -->

--- a/src/rules/bem/no-grouped-entities/no-grouped-entities.ts
+++ b/src/rules/bem/no-grouped-entities/no-grouped-entities.ts
@@ -1,0 +1,281 @@
+import { isEmpty } from '@morev/utils';
+import * as v from 'valibot';
+import { resolveMostSpecificBemEntities } from '#modules/bem';
+import { isSelectorOwnerNode } from '#modules/postcss';
+import { createRule, extractSeparators, mergeMessages, vMessagesSchema, vSeparatorsSchema } from '#modules/rule-utils';
+import { getResolvedNodesSourceRange, resolveSelectorNodes, selectorNodesToString, splitSelectorCompounds } from '#modules/selectors';
+import type { AtRule, Node, Rule } from 'postcss';
+import type parser from 'postcss-selector-parser';
+import type { ResolvedNode } from '#modules/selectors';
+import type { Separators } from '#modules/shared';
+
+const IGNORED_FUNCTIONAL_PSEUDOS = new Set([':has', ':is', ':not', ':where']);
+
+type SourceRange = {
+	/**
+	 * End index in the selector source.
+	 */
+	endIndex: number;
+
+	/**
+	 * Start index in the selector source.
+	 */
+	index: number;
+};
+
+type BranchAnalysis = {
+	/**
+	 * Whether at least one resolution path has no unambiguous target.
+	 */
+	isAmbiguous: boolean;
+
+	/**
+	 * Range of the complete authored selector-list branch.
+	 */
+	range: SourceRange;
+
+	/**
+	 * Unique resolved targets and their authored source ranges.
+	 */
+	targets: Map<string, SourceRange>;
+};
+
+type SelectorListAnalysis = {
+	/**
+	 * First authored range of every distinct BEM target in source order.
+	 */
+	targets: Map<string, SourceRange>;
+
+	/**
+	 * Selector-owning PostCSS node.
+	 */
+	node: Rule | AtRule;
+};
+
+/**
+ * Detects selector lists nested inside functional pseudo-classes.
+ * Their branches are intentionally outside the initial ownership model.
+ *
+ * @param   nodes   Selector nodes to inspect recursively.
+ *
+ * @returns         Whether an ignored nested selector list is present.
+ */
+const hasIgnoredFunctionalSelectorList = (nodes: parser.Node[]): boolean => {
+	return nodes.some((node) => {
+		if (
+			node.type === 'pseudo'
+			&& IGNORED_FUNCTIONAL_PSEUDOS.has(node.value)
+			&& (node.nodes?.length ?? 0) > 1
+		) return true;
+
+		if (!('nodes' in node) || isEmpty(node.nodes)) return false;
+
+		return node.nodes.some((child) => hasIgnoredFunctionalSelectorList([child]));
+	});
+};
+
+/**
+ * Resolves one unambiguous BEM target from an authored selector-list branch.
+ * The most specific entity from the rightmost compound owns the declarations.
+ *
+ * @param   source       Authored selector branch.
+ * @param   resolved     Resolved selector branch.
+ * @param   separators   BEM separators used in the current config.
+ *
+ * @returns              Canonical BEM identity and its authored source range, or `null`.
+ */
+const resolveBranchTarget = (
+	source: parser.Node[],
+	resolved: ResolvedNode[],
+	separators: Separators,
+) => {
+	if (
+		selectorNodesToString(resolved).includes('#{')
+		|| hasIgnoredFunctionalSelectorList(source)
+		|| hasIgnoredFunctionalSelectorList(resolved)
+	) return null;
+
+	const targetCompound = splitSelectorCompounds(resolved).at(-1);
+	if (!targetCompound) return null;
+
+	const entities = resolveMostSpecificBemEntities({
+		nodes: targetCompound,
+		separators,
+	});
+	if (entities.length !== 1) return null;
+
+	const [{ bemSelector: entity }] = entities;
+	const targetNode = targetCompound.findLast((node) => {
+		return node.type === 'class' && node.value === entity.slice(1);
+	});
+	if (!targetNode) return null;
+
+	const range = getResolvedNodesSourceRange([targetNode]);
+	if (!range) return null;
+
+	return { entity, range };
+};
+
+/**
+ * Resolves unambiguous BEM targets from the authored branches of one selector list.
+ * Parent selector-list expansions are collapsed back into their authored branches.
+ *
+ * @param   node         Selector-owning PostCSS node.
+ * @param   separators   BEM separators used in the current config.
+ *
+ * @returns              Selector-list analysis, or `null` when no target can be resolved.
+ */
+const analyzeSelectorList = (
+	node: Rule | AtRule,
+	separators: Separators,
+): SelectorListAnalysis | null => {
+	const branches = new Map<string, BranchAnalysis>();
+
+	for (const { resolved, source } of resolveSelectorNodes({ node })) {
+		const branchRange = getResolvedNodesSourceRange(resolved);
+		if (!branchRange) continue;
+
+		const branchKey = `${branchRange.index}:${branchRange.endIndex}`;
+		const branch = branches.get(branchKey) ?? {
+			isAmbiguous: false,
+			range: branchRange,
+			targets: new Map<string, SourceRange>(),
+		};
+		branches.set(branchKey, branch);
+
+		const target = resolveBranchTarget(source, resolved, separators);
+		if (!target) {
+			branch.isAmbiguous = true;
+			continue;
+		}
+
+		branch.targets.set(target.entity, target.range);
+	}
+
+	const targets = new Map<string, SourceRange>();
+	const unambiguousBranches = [...branches.values()]
+		.filter((branch) => !branch.isAmbiguous && branch.targets.size === 1)
+		.toSorted((a, b) => a.range.index - b.range.index);
+
+	for (const branch of unambiguousBranches) {
+		const [[entity, range]] = branch.targets;
+		if (!targets.has(entity)) targets.set(entity, range);
+	}
+	if (targets.size === 0) return null;
+
+	return { node, targets };
+};
+
+/**
+ * Checks whether a selector-owning node belongs to the lexical subtree of a group.
+ *
+ * @param   node    Candidate node.
+ * @param   group   Selector-list group that may own the candidate.
+ *
+ * @returns         Whether the candidate is the group itself or one of its descendants.
+ */
+const isWithinGroup = (node: Node, group: Node) => {
+	let current: Node | undefined = node;
+
+	while (current) {
+		if (current === group) return true;
+		current = current.parent;
+	}
+
+	return false;
+};
+
+export default createRule({
+	scope: 'bem',
+	name: 'no-grouped-entities',
+	meta: {
+		description: 'Prevents BEM entities from having both grouped and separate declarations.',
+		deprecated: false,
+		fixable: false,
+	},
+	messages: {
+		grouped: (entity: string, owner: string) =>
+			`Unexpected BEM entity "${entity}" grouped with "${owner}". Declare each entity in a separate rule.`,
+		redeclared: (entity: string, line: number) =>
+			`Unexpected BEM entity "${entity}" grouped here; another declaration occurs at line ${line}. Extract it into its own rule.`,
+	},
+	schema: {
+		primary: v.literal(true),
+		secondary: v.optional(
+			v.object({
+				strict: v.optional(v.boolean(), false),
+				separators: vSeparatorsSchema,
+				messages: vMessagesSchema({
+					grouped: [v.string(), v.string()],
+					redeclared: [v.string(), v.number()],
+				}),
+			}),
+		),
+	},
+}, (primary, secondary, { report, messages: ruleMessages, root }) => {
+	const messages = mergeMessages(ruleMessages, secondary.messages);
+	const separators = extractSeparators(secondary.separators);
+	const analyses: SelectorListAnalysis[] = [];
+
+	// Collect all selector-list analyses before reporting.
+	// Default behavior needs the complete registry
+	// to find declarations outside each group.
+	root.walk((node) => {
+		if (!isSelectorOwnerNode(node)) return;
+
+		const analysis = analyzeSelectorList(node, separators);
+		if (analysis) analyses.push(analysis);
+	});
+
+	if (secondary.strict) {
+		// Use the first distinct target as a reference
+		// and report every later target against it.
+		for (const analysis of analyses) {
+			const targets = [...analysis.targets];
+			const [firstTarget] = targets;
+			if (!firstTarget) continue;
+
+			const [owner] = firstTarget;
+
+			for (const [entity, range] of targets.slice(1)) {
+				report({
+					...range,
+					node: analysis.node,
+					message: messages.grouped(entity, owner),
+					messageArgs: ['grouped', entity, owner],
+				});
+			}
+		}
+		return;
+	}
+
+	// States and pseudo-elements of one entity collapse
+	// to a single target and do not form a group.
+	for (const analysis of analyses) {
+		if (analysis.targets.size < 2) continue;
+
+		for (const [entity, range] of analysis.targets) {
+			// Descendants remain owned by the original group
+			// and do not count as separate declarations.
+			const redeclaration = analyses.find((candidate) => {
+				return !isWithinGroup(candidate.node, analysis.node)
+					&& candidate.targets.has(entity);
+			});
+			const redeclarationRange = redeclaration?.targets.get(entity);
+
+			if (redeclaration && redeclarationRange) {
+				// Reference the matching target's line
+				// instead of the start of its selector-owning rule.
+				const redeclarationLine = redeclaration.node
+					.positionBy({ index: redeclarationRange.index }).line;
+
+				report({
+					...range,
+					node: analysis.node,
+					message: messages.redeclared(entity, redeclarationLine),
+					messageArgs: ['redeclared', entity, redeclarationLine],
+				});
+			}
+		}
+	}
+});

--- a/src/rules/bem/no-grouped-entities/no-grouped-entities.types.ts
+++ b/src/rules/bem/no-grouped-entities/no-grouped-entities.types.ts
@@ -1,0 +1,51 @@
+import type { Separators } from '#modules/shared';
+
+/**
+ * Primary option of the rule.
+ */
+export type PrimaryOption = true;
+
+/**
+ * Secondary options of the rule.
+ */
+export type SecondaryOption = {
+	/**
+	 * Custom message functions for rule violations.
+	 */
+	messages?: {
+		/**
+		 * Custom message for a BEM entity grouped with another declaration owner.
+		 *
+		 * @param   entity   Grouped BEM entity.
+		 * @param   owner    First BEM entity in the selector list.
+		 *
+		 * @returns          The error message to report.
+		 */
+		grouped?: (entity: string, owner: string) => string;
+
+		/**
+		 * Custom message for a grouped BEM entity that is declared outside its selector group.
+		 *
+		 * @param   entity   Redeclared grouped BEM entity.
+		 * @param   line     Line of the matching external declaration.
+		 *
+		 * @returns          The error message to report.
+		 */
+		redeclared?: (entity: string, line: number) => string;
+	};
+
+	/**
+	 * Whether to reject every selector list that targets different BEM entities.
+	 * When disabled, grouping is allowed until a grouped entity is declared outside the group's lexical subtree.
+	 *
+	 * @default false
+	 */
+	strict?: boolean;
+
+	/**
+	 * Object that defines BEM separators used to distinguish blocks, elements, modifiers, and modifier values.
+	 *
+	 * @default { element: '__', modifier: '--', modifierValue: '--' }
+	 */
+	separators?: Partial<Separators>;
+};

--- a/src/rules/bem/no-misplaced-relational-styles/no-misplaced-relational-styles.ts
+++ b/src/rules/bem/no-misplaced-relational-styles/no-misplaced-relational-styles.ts
@@ -1,53 +1,11 @@
-import { arrayUnique, isEmpty } from '@morev/utils';
+import { isEmpty } from '@morev/utils';
 import * as v from 'valibot';
-import { getBemBlock, isDirectBemEntity, resolveBemEntities } from '#modules/bem';
-import { isAtRule, isKeyframesRule, isRule } from '#modules/postcss';
+import { getBemBlock, resolveMostSpecificBemEntities } from '#modules/bem';
+import { isSelectorOwnerNode } from '#modules/postcss';
 import { createRule, extractSeparators, mergeMessages, vMessagesSchema, vSeparatorsSchema } from '#modules/rule-utils';
-import { getResolvedNodesSourceRange, resolveSelectorNodes, selectorNodesToString } from '#modules/selectors';
+import { getResolvedNodesSourceRange, resolveSelectorNodes, selectorNodesToString, splitSelectorCompounds } from '#modules/selectors';
 import type parser from 'postcss-selector-parser';
-import type { BemEntity } from '#modules/bem';
 import type { Separators } from '#modules/shared';
-
-/**
- * Splits a flat selector branch at top-level combinators.
- * For example, `.block:hover > .block__label` becomes two compounds:
- * `.block:hover` and `.block__label`.
- *
- * Combinators inside functional pseudos remain part of their containing node,
- * so `:has(.foo .bar)` is not split here.
- *
- * @param   nodes   Parsed selector nodes from one branch.
- *
- * @returns         Non-empty compounds in source order.
- */
-const splitCompounds = <Node extends parser.Node>(nodes: Node[]) => {
-	const compounds: Node[][] = [[]];
-
-	for (const node of nodes) {
-		if (node.type === 'combinator') {
-			compounds.push([]);
-			continue;
-		}
-
-		compounds.at(-1)!.push(node);
-	}
-
-	return compounds.filter((compound) => !isEmpty(compound));
-};
-
-/**
- * Ranks a BEM entity by the number of parts after its block.
- * For example, `.block` has rank 0, `.block__item` has rank 1,
- * and `.block__item--active` has rank 2.
- *
- * @param   entity   Resolved BEM entity.
- *
- * @returns          Structural depth of the entity.
- */
-const getEntitySpecificity = (entity: BemEntity) => {
-	return [entity.element, entity.modifierName, entity.modifierValue]
-		.filter(Boolean).length;
-};
 
 /**
  * Resolves the deepest direct BEM entities of the requested block in a compound.
@@ -68,18 +26,8 @@ const getMostSpecificEntities = (
 	blockName: string,
 	separators: Separators,
 ) => {
-	const selector = selectorNodesToString(nodes);
-	const entities = resolveBemEntities({ source: selector, separators })
-		.filter((entity) => entity.block.value === blockName)
-		.filter(isDirectBemEntity);
-	if (isEmpty(entities)) return [];
-
-	const highestSpecificity = Math.max(...entities.map((entity) => getEntitySpecificity(entity)));
-	return arrayUnique(
-		entities
-			.filter((entity) => getEntitySpecificity(entity) === highestSpecificity)
-			.map((entity) => entity.bemSelector),
-	);
+	return resolveMostSpecificBemEntities({ blockName, nodes, separators })
+		.map((entity) => entity.bemSelector);
 };
 
 /**
@@ -132,8 +80,7 @@ export default createRule({
 	root.walk((node) => {
 		// Only constructs that can own selectors participate in the rule.
 		// Keyframe steps such as `from` and `50%` must never be interpreted as selector ownership.
-		if (isKeyframesRule(node)) return;
-		if (!isAtRule(node, ['nest', 'at-root']) && !isRule(node)) return;
+		if (!isSelectorOwnerNode(node)) return;
 
 		const reportedViolations = new Set<string>();
 
@@ -147,7 +94,7 @@ export default createRule({
 
 			// A relation needs at least a source and a target compound.
 			// `.block__label:hover` is local state; `.block:hover .block__label` is a relation.
-			const compounds = splitCompounds(resolved);
+			const compounds = splitSelectorCompounds(resolved);
 			if (compounds.length < 2) return;
 
 			// A nested state may inherit an already-authored relation:
@@ -198,7 +145,7 @@ export default createRule({
 			// participates in the emitted selector. A flat relation still has no owner.
 			const ownerEntities = lexicalParent
 				? getMostSpecificEntities(
-					splitCompounds(lexicalParent).at(-1)!,
+					splitSelectorCompounds(lexicalParent).at(-1)!,
 					bemBlock.blockName,
 					separators,
 				)

--- a/src/rules/bem/no-side-effects/no-side-effects.ts
+++ b/src/rules/bem/no-side-effects/no-side-effects.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from '@morev/utils';
 import * as v from 'valibot';
 import { getBemBlock } from '#modules/bem';
-import { isAtRule, isKeyframesRule, isRule } from '#modules/postcss';
+import { isSelectorOwnerNode } from '#modules/postcss';
 import { createRule, extractSeparators, mergeMessages, vMessagesSchema, vSeparatorsSchema, vStringOrRegExpSchema } from '#modules/rule-utils';
 import { resolveSelectorNodes } from '#modules/selectors';
 import { toRegExp } from '#modules/shared';
@@ -48,9 +48,8 @@ export default createRule({
 	root.walk((node) => {
 		// Do not check the block itself
 		if (node === bemBlock.rule) return;
-		if (isKeyframesRule(node)) return;
 		// All other constructs are irrelevant to selector analysis.
-		if (!isAtRule(node, ['nest', 'at-root']) && !isRule(node)) return;
+		if (!isSelectorOwnerNode(node)) return;
 
 		resolveSelectorNodes({ node }).forEach(({ resolved }) => {
 			// Incomplete input

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -4,6 +4,7 @@ export { default as blockVariable } from './bem/block-variable/block-variable';
 export { default as matchFileName } from './bem/match-file-name/match-file-name';
 export { default as noBlockProperties } from './bem/no-block-properties/no-block-properties';
 export { default as noChainedEntities } from './bem/no-chained-entities/no-chained-entities';
+export { default as noGroupedEntities } from './bem/no-grouped-entities/no-grouped-entities';
 export { default as noMisplacedRelationalStyles } from './bem/no-misplaced-relational-styles/no-misplaced-relational-styles';
 export { default as noSideEffects } from './bem/no-side-effects/no-side-effects';
 export { default as selectorPattern } from './bem/selector-pattern/selector-pattern';


### PR DESCRIPTION
Closes #70.

- Add default and strict grouping checks.
- Report the matching external declaration line.
- Add shared selector utilities, tests, types, and documentation.